### PR TITLE
fix error

### DIFF
--- a/config/operator/rbac/role.yaml
+++ b/config/operator/rbac/role.yaml
@@ -46,6 +46,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create

--- a/controllers/operator/javaagent_controller.go
+++ b/controllers/operator/javaagent_controller.go
@@ -168,6 +168,12 @@ func (r *JavaAgentReconciler) updateStatus(ctx context.Context, log logr.Logger,
 		errCol.Collect(fmt.Errorf("failed to get javaagent: %w", err))
 	}
 
+	// avoid printing error info when the javaagent is creating
+	if javaagent.Name == "" {
+		log.Info("javaagent is creating...", "name", selectorname+"-javaagent")
+		return errCol.Error()
+	}
+
 	// return all pods in the request namespace with the podselector
 	podList := &core.PodList{}
 	label := strings.Split(podselector, "=")

--- a/controllers/operator/oapserver_controller.go
+++ b/controllers/operator/oapserver_controller.go
@@ -57,6 +57,7 @@ type OAPServerReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=*
 // +kubebuilder:rbac:groups=operator.skywalking.apache.org,resources=storages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.skywalking.apache.org,resources=storages/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *OAPServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("oapserver", req.NamespacedName)

--- a/controllers/operator/ui_controller.go
+++ b/controllers/operator/ui_controller.go
@@ -48,6 +48,7 @@ type UIReconciler struct {
 // +kubebuilder:rbac:groups=operator.skywalking.apache.org,resources=uis,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=operator.skywalking.apache.org,resources=uis/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *UIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("ui", req.NamespacedName)

--- a/docs/java-agent-injector.md
+++ b/docs/java-agent-injector.md
@@ -138,7 +138,7 @@ The optional plugin configuration is the annotation as below.
 
 | Annotation key                   | Description                                                  | Annotation value |
 | -------------------------------- | ------------------------------------------------------------ | ---------------- |
-| `optional.skywalking.apache.org` | Select the optional plugin which needs to be moved to the directory(/plugins). Users can select several optional plugins by separating from `|`, such as `trace|webflux|cloud-gateway-2.1.x`. | not set          |
+| `optional.skywalking.apache.org` | Select the optional plugin which needs to be moved to the directory(/plugins). Users can select several optional plugins by separating from `｜`, such as `trace｜webflux｜cloud-gateway-2.1.x`. | not set          |
 
 #### 5. optional reporter plugin configuration
 
@@ -146,7 +146,7 @@ The optional reporter plugin configuration is the annotation as below.
 
 | Annotation key                            | Description                                                  | Annotation value |
 | ----------------------------------------- | ------------------------------------------------------------ | ---------------- |
-| `optional-reporter.skywalking.apache.org` | Select the optional reporter plugin which needs to be moved to the directory(/plugins). Users can select several optional reporter plugins by separating from `|`, such as `kafka`. | not set          |
+| `optional-reporter.skywalking.apache.org` | Select the optional reporter plugin which needs to be moved to the directory(/plugins). Users can select several optional reporter plugins by separating from `｜`, such as `kafka`. | not set          |
 
 ## Configure sidecar
 


### PR DESCRIPTION
1. fix display error in markdown , like 
![image](https://user-images.githubusercontent.com/71587243/137587485-0e1c3b68-c366-4d52-a569-ce4d66ba8c74.png)
2. fix error about updating javaagent's status. When we apply the JavaAgent(custom definition), it may take a while to create.
3. when I create the default UI and oapserver, it may cause some error as below.
```
E1016 08:59:58.460340    1 event.go:264] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"default.16ae773847ef2a16", GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"OAPServer", Namespace:"default", Name:"default", UID:"df04ca10-701d-4f14-ae3f-c65847300680", APIVersion:"operator.skywalking.apache.org/v1alpha1", ResourceVersion:"557058", FieldPath:""}, Reason:"resources are created or updated", Message:"resources: [oapserver/templates/cluster_role.yaml oapserver/templates/cluster_role_binding.yaml oapserver/templates/deployment.yaml oapserver/templates/service.yaml oapserver/templates/service_account.yaml]", Source:v1.EventSource{Component:"oapserver-controller", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xc052c303974b1e16, ext:152912802000, loc:(*time.Location)(0x25ab320)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xc052c303974b1e16, ext:152912802000, loc:(*time.Location)(0x25ab320)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "system:serviceaccount:skywalking-swck-system:default" cannot create resource "events" in API group "" in the namespace "default"' (will not retry!)
``` 
So we need to add the RBAC rule like `// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch`