### PR TITLE
Several improvements for 0.4.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Release Notes.
 - Bump up GO to 1.17.
 - Bump up k8s api to 0.20.11.
 - Polish documents.
+- Bump up SkyWalking OAP to 8.8.1.
 
 0.3.0
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -193,10 +193,10 @@ update-templates: $(GO_BINDATA)
 	-hack/build-header.sh pkg/operator/repo/assets.gen.go
 
 release-operator: generate
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o build/bin/manager-linux-amd64 cmd/manager/manager.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags="-s -w" -o build/bin/manager-linux-amd64 cmd/manager/manager.go
 
 release-adapter: generate
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o build/bin/adapter-linux-amd64 cmd/adapter/adapter.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags="-s -w" -o build/bin/adapter-linux-amd64 cmd/adapter/adapter.go
 
 RELEASE_SCRIPTS := ./build/package/release.sh
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ SWCK is a platform for the SkyWalking user, provisions, upgrades, maintains SkyW
 
 ## Java Agent Injector
 
+The java agent injector share the same binary with the operator. Follow the installation procedure of the operator
+to onboard the injector.
+
+The injector can:
+
 * Inject the java agent into the application pod.
-* Use the default agent configuration.
-* Use annotations to overlay sidecar configuration and agent configuration.
-* Get the final injected agent's configuration.
+* Leverage a global configuration to simplify the agent and injector setup.
+* Use the annotation to customize specific workloads.
+* Sync injecting status to `JavaAgent` CR for monitoring purpose.
 
 For more details, please read [Java agent injector](docs/java-agent-injector.md)
 

--- a/apis/operator/v1alpha1/oapserver_webhook.go
+++ b/apis/operator/v1alpha1/oapserver_webhook.go
@@ -48,19 +48,7 @@ func (r *OAPServer) Default() {
 
 	image := r.Spec.Image
 	if image == "" {
-		v := r.Spec.Version
-		vTmpl := "apache/skywalking-oap-server:%s-%s"
-		vES := "es6"
-		for _, e := range r.Spec.Config {
-			if e.Name != "SW_STORAGE" {
-				continue
-			}
-			if e.Value == "elasticsearch7" {
-				vES = "es7"
-			}
-		}
-		image = fmt.Sprintf(vTmpl, v, vES)
-		r.Spec.Image = image
+		r.Spec.Image = fmt.Sprintf("apache/skywalking-oap-server:%s", r.Spec.Version)
 	}
 	for _, envVar := range r.Spec.Config {
 		if envVar.Name == "SW_ENVOY_METRIC_ALS_HTTP_ANALYSIS" &&

--- a/build/images/Dockerfile.release-bin
+++ b/build/images/Dockerfile.release-bin
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/distroless/static:nonroot
+COPY --chown=nonroot:nonroot bin/manager-linux-amd64 /manager
+COPY --chown=nonroot:nonroot bin/adapter-linux-amd64 /adapter
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]

--- a/config/operator/samples/default.yaml
+++ b/config/operator/samples/default.yaml
@@ -20,9 +20,9 @@ kind: OAPServer
 metadata:
   name: default
 spec:
-  version: 8.3.0
+  version: 8.8.1
   instances: 1
-  image: apache/skywalking-oap-server:8.3.0-es6
+  image: apache/skywalking-oap-server:8.8.1
   service:
     template:
       type: ClusterIP
@@ -33,9 +33,9 @@ kind: UI
 metadata:
   name: default
 spec:
-  version: 8.3.0
+  version: 8.8.1
   instances: 1
-  image: apache/skywalking-ui:8.3.0
+  image: apache/skywalking-ui:8.8.1
   OAPServerAddress: default-oap:12800
   service:
     template:

--- a/config/operator/samples/fetcher.yaml
+++ b/config/operator/samples/fetcher.yaml
@@ -30,9 +30,9 @@ kind: OAPServer
 metadata:
   name: default
 spec:
-  version: 8.3.0
+  version: 8.8.1
   instances: 1
-  image: apache/skywalking-oap-server:8.3.0-es6
+  image: apache/skywalking-oap-server:8.8.1
   config:
     - name: SW_OTEL_RECEIVER
       value: default
@@ -46,9 +46,9 @@ kind: UI
 metadata:
   name: default
 spec:
-  version: 8.3.0
+  version: 8.8.1
   instances: 1
-  image: apache/skywalking-ui:8.3.0
+  image: apache/skywalking-ui:8.8.1
   OAPServerAddress: default-oap:12800
   service:
     template:

--- a/config/operator/samples/minimal.yaml
+++ b/config/operator/samples/minimal.yaml
@@ -20,7 +20,7 @@ kind: OAPServer
 metadata:
   name: minimal
 spec:
-  version: 8.3.0
+  version: 8.8.1
   instances: 1
   
 ---
@@ -29,6 +29,6 @@ kind: UI
 metadata:
   name: minimal
 spec:
-  version: 8.3.0
+  version: 8.8.1
   instances: 1
  

--- a/docs/binary-readme.md
+++ b/docs/binary-readme.md
@@ -1,0 +1,55 @@
+Apache SkyWalking Cloud on Kubernetes
+============
+
+![](https://github.com/apache/skywalking-swck/workflows/Build/badge.svg?branch=master)
+
+<img src="http://skywalking.apache.org/assets/logo.svg" alt="Sky Walking logo" height="90px" align="right" />
+
+A bridge project between [Apache SkyWalking](https://github.com/apache/skywalking) and Kubernetes.
+
+SWCK is a platform for the SkyWalking user, provisions, upgrades, maintains SkyWalking relevant components, and makes them work natively on Kubernetes.
+
+# Features
+
+1. Java Agent Injector: Inject the java agent into the application pod natively.
+1. Operator: Provision and maintain SkyWalking backend components.
+1. Custom Metrics Adapter: Provides custom metrics come from SkyWalking OAP cluster for autoscaling by Kubernetes HPA
+
+# Build images
+
+Issue below instrument to get the docker image:
+
+```
+make
+```
+
+or 
+
+```
+make build
+```
+
+To onboard operator or adapter, you should push the image to a registry where the kubernetes cluster can pull it.
+
+## Onboard Java Agent Injector and Operator
+
+The java agent injector and operator share a same binary. To onboard them, you should follow:
+
+* To install the java agent injector and operator in an existing cluster, make sure you have [`cert-manager` installed](https://cert-manager.io/docs/installation/)
+* Apply the manifests for the Controller and CRDs in `config`:
+
+ ```
+ kubectl apply -f config/operator-bundle.yaml
+ ```
+
+## Onboard Custom Metrics Adapter
+
+* Deploy OAP server by referring to Operator Quick Start.
+* Apply the manifests for an adapter in `config`:
+
+ ```
+ kubectl apply -f config/adapter-bundle.yaml
+ ```
+
+# License
+[Apache 2.0 License.](/LICENSE)

--- a/docs/examples/storage.md
+++ b/docs/examples/storage.md
@@ -84,9 +84,9 @@ kind: OAPServer
 metadata:
   name: default
 spec:
-  version: 8.3.0
+  version: 8.8.1
   instances: 1
-  image: apache/skywalking-oap-server:8.3.0-es7
+  image: apache/skywalking-oap-server:8.8.1
   service:
     template:
       type: ClusterIP

--- a/docs/release.md
+++ b/docs/release.md
@@ -19,7 +19,7 @@ This documentation guides the release manager to release the SkyWalking Cloud on
 ```shell
 export VERSION=<the version to release>
 git clone git@github.com:apache/skywalking-swck && cd skywalking-swck
-git tag -a "$VERSION" -m "Release Apache SkyWalking Cloud on Kubernetes $VERSION"
+git tag -a "v$VERSION" -m "Release Apache SkyWalking Cloud on Kubernetes $VERSION"
 git push --tags
 make clean && make release
 ```


### PR DESCRIPTION
  * Bump up SkyWalking OAP to 8.8.1(latest)
  * Update README.md laid in the binary package
  * Add a docker build tool to the binary package where users can
    build the docker image from binaries in the bin folder
  * Update release document and bash script to insert "v" into
    the git release tag. Closes 
 https://github.com/apache/skywalking/issues/6657

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>