### PR TITLE
Fix operator role patch issues

### DIFF
--- a/config/operator/rbac/kustomization.yaml
+++ b/config/operator/rbac/kustomization.yaml
@@ -28,6 +28,11 @@ resources:
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
 
-patchesStrategicMerge:
-- role_patch.yaml
+patchesJson6902:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: manager-role
+  path: role_patch.yaml
   

--- a/config/operator/rbac/role_patch.yaml
+++ b/config/operator/rbac/role_patch.yaml
@@ -15,17 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: manager-role
-rules:
-  - apiGroups:
-      - certificates.k8s.io
+- op: add
+  path: /rules/0
+  value:
+    apiGroups:
+    - certificates.k8s.io
     resources:
-      - signers
+    - signers
     resourceNames:
-      - kubernetes.io/*
+    - kubernetes.io/*
     verbs:
-      - approve
+    - approve
+        


### PR DESCRIPTION
Using JSON patch instead of patch merge strategy to add a rule which is not supported by kubebuilder

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>