### PR TITLE
Remove deprecated Kubernetes API dependence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 OPERATOR_IMG ?= controller:latest
 ADAPTER_IMG ?= metrics-adapter:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= crd
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -143,7 +143,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/apis/operator/v1alpha1/fetcher_webhook.go
+++ b/apis/operator/v1alpha1/fetcher_webhook.go
@@ -36,7 +36,7 @@ func (r *Fetcher) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:path=/mutate-operator-skywalking-apache-org-v1alpha1-fetcher,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=fetchers,verbs=create;update,versions=v1alpha1,name=mfetcher.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,path=/mutate-operator-skywalking-apache-org-v1alpha1-fetcher,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=fetchers,verbs=create;update,versions=v1alpha1,name=mfetcher.kb.io
 
 var _ webhook.Defaulter = &Fetcher{}
 
@@ -49,7 +49,7 @@ func (r *Fetcher) Default() {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-fetcher,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=fetchers,versions=v1alpha1,name=vfetcher.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-fetcher,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=fetchers,versions=v1alpha1,name=vfetcher.kb.io
 
 var _ webhook.Validator = &Fetcher{}
 

--- a/apis/operator/v1alpha1/javaagent_injector_webhook.go
+++ b/apis/operator/v1alpha1/javaagent_injector_webhook.go
@@ -33,7 +33,7 @@ import (
 var javaagentInjectorLog = logf.Log.WithName("javaagent_injector")
 
 // nolint: lll
-// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,path=/mutate-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io
 
 // Javaagent injects java agent into Pods
 type JavaagentInjector struct {

--- a/apis/operator/v1alpha1/javaagent_webhook.go
+++ b/apis/operator/v1alpha1/javaagent_webhook.go
@@ -38,7 +38,7 @@ func (r *JavaAgent) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:path=/mutate-operator-skywalking-apache-org-v1alpha1-javaagent,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=javaagents,verbs=create;update,versions=v1alpha1,name=mjavaagent.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,path=/mutate-operator-skywalking-apache-org-v1alpha1-javaagent,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=javaagents,verbs=create;update,versions=v1alpha1,name=mjavaagent.kb.io
 
 var _ webhook.Defaulter = &JavaAgent{}
 
@@ -63,7 +63,7 @@ func (r *JavaAgent) Default() {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-javaagent,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=javaagents,versions=v1alpha1,name=vjavaagent.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-javaagent,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=javaagents,versions=v1alpha1,name=vjavaagent.kb.io
 
 var _ webhook.Validator = &JavaAgent{}
 

--- a/apis/operator/v1alpha1/oapserver_webhook.go
+++ b/apis/operator/v1alpha1/oapserver_webhook.go
@@ -38,7 +38,7 @@ func (r *OAPServer) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:path=/mutate-operator-skywalking-apache-org-v1alpha1-oapserver,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=oapservers,verbs=create;update,versions=v1alpha1,name=moapserver.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,path=/mutate-operator-skywalking-apache-org-v1alpha1-oapserver,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=oapservers,verbs=create;update,versions=v1alpha1,name=moapserver.kb.io
 
 var _ webhook.Defaulter = &OAPServer{}
 
@@ -61,7 +61,7 @@ func (r *OAPServer) Default() {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-oapserver,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=oapservers,versions=v1alpha1,name=voapserver.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-oapserver,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=oapservers,versions=v1alpha1,name=voapserver.kb.io
 
 var _ webhook.Validator = &OAPServer{}
 

--- a/apis/operator/v1alpha1/storage_webhook.go
+++ b/apis/operator/v1alpha1/storage_webhook.go
@@ -37,7 +37,7 @@ func (r *Storage) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:path=/mutate-operator-skywalking-apache-org-v1alpha1-storage,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=storages,verbs=create;update,versions=v1alpha1,name=mstorage.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,path=/mutate-operator-skywalking-apache-org-v1alpha1-storage,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=storages,verbs=create;update,versions=v1alpha1,name=mstorage.kb.io
 
 var _ webhook.Defaulter = &Storage{}
 
@@ -55,7 +55,7 @@ func (r *Storage) Default() {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-storage,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=storages,versions=v1alpha1,name=vstorage.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-storage,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=storages,versions=v1alpha1,name=vstorage.kb.io
 
 var _ webhook.Validator = &Storage{}
 

--- a/apis/operator/v1alpha1/ui_webhook.go
+++ b/apis/operator/v1alpha1/ui_webhook.go
@@ -36,7 +36,7 @@ func (r *UI) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:path=/mutate-operator-skywalking-apache-org-v1alpha1-ui,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=uis,verbs=create;update,versions=v1alpha1,name=mui.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,path=/mutate-operator-skywalking-apache-org-v1alpha1-ui,mutating=true,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=uis,verbs=create;update,versions=v1alpha1,name=mui.kb.io
 
 var _ webhook.Defaulter = &UI{}
 
@@ -55,7 +55,7 @@ func (r *UI) Default() {
 }
 
 // nolint: lll
-// +kubebuilder:webhook:verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-ui,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=uis,versions=v1alpha1,name=vui.kb.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,sideEffects=None,verbs=create;update,path=/validate-operator-skywalking-apache-org-v1alpha1-ui,mutating=false,failurePolicy=fail,groups=operator.skywalking.apache.org,resources=uis,versions=v1alpha1,name=vui.kb.io
 
 var _ webhook.Validator = &UI{}
 

--- a/config/dev/operator/crd/bases/operator.skywalking.apache.org_fetchers.yaml
+++ b/config/dev/operator/crd/bases/operator.skywalking.apache.org_fetchers.yaml
@@ -17,11 +17,11 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: fetchers.operator.skywalking.apache.org
 spec:
@@ -32,86 +32,86 @@ spec:
     plural: fetchers
     singular: fetcher
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Fetcher is the Schema for the fetchers API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: FetcherSpec defines the desired state of Fetcher
-          properties:
-            OAPServerAddress:
-              description: OAPServerAddress is the address of backend OAPServers
-              type: string
-            clusterName:
-              description: ClusterName
-              type: string
-            type:
-              description: Fetcher is the type of how to fetch metrics from target.
-              items:
-                description: Service Type string describes ingress methods for a service
-                type: string
-              type: array
-          type: object
-        status:
-          description: FetcherStatus defines the observed state of Fetcher
-          properties:
-            conditions:
-              description: Represents the latest available observations of a fetcher's
-                current state.
-              items:
-                description: DeploymentCondition describes the state of a deployment
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of deployment condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            replicas:
-              description: Replicas is currently not being set and might be removed
-                in the next version.
-              format: int32
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Fetcher is the Schema for the fetchers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FetcherSpec defines the desired state of Fetcher
+            properties:
+              OAPServerAddress:
+                description: OAPServerAddress is the address of backend OAPServers
+                type: string
+              clusterName:
+                description: ClusterName
+                type: string
+              type:
+                description: Fetcher is the type of how to fetch metrics from target.
+                items:
+                  description: Service Type string describes ingress methods for a
+                    service
+                  type: string
+                type: array
+            type: object
+          status:
+            description: FetcherStatus defines the observed state of Fetcher
+            properties:
+              conditions:
+                description: Represents the latest available observations of a fetcher's
+                  current state.
+                items:
+                  description: DeploymentCondition describes the state of a deployment
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of deployment condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              replicas:
+                description: Replicas is currently not being set and might be removed
+                  in the next version.
+                format: int32
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/dev/operator/crd/bases/operator.skywalking.apache.org_javaagents.yaml
+++ b/config/dev/operator/crd/bases/operator.skywalking.apache.org_javaagents.yaml
@@ -17,27 +17,14 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: javaagents.operator.skywalking.apache.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.podSelector
-    description: The selector label of injected Pod
-    name: PodSelector
-    type: string
-  - JSONPath: .spec.serviceName
-    description: The name of service in the injected agent
-    name: ServiceName
-    type: string
-  - JSONPath: .spec.backendService
-    description: The backend service in the injected agent
-    name: BackendService
-    type: string
   group: operator.skywalking.apache.org
   names:
     kind: JavaAgent
@@ -45,68 +32,80 @@ spec:
     plural: javaagents
     singular: javaagent
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: JavaAgent is the Schema for the javaagents API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: JavaAgentSpec defines the desired state of JavaAgent
-          properties:
-            agentConfiguration:
-              additionalProperties:
-                type: string
-              description: AgentConfiguration is the injected agent's final configuration
-              type: object
-            backendService:
-              description: BackendService is the backend service in the injected agent,
-                which need to be printed
-              type: string
-            podSelector:
-              description: PodSelector is the selector label of injected Pod
-              type: string
-            serviceName:
-              description: ServiceName is the name of service in the injected agent,
-                which need to be printed
-              type: string
-          type: object
-        status:
-          description: JavaAgentStatus defines the observed state of JavaAgent
-          properties:
-            creationTime:
-              description: The time the JavaAgent was created.
-              format: date-time
-              type: string
-            expectedInjectiedNum:
-              description: The number of pods that need to be injected
-              type: integer
-            lastUpdateTime:
-              description: The last time this condition was updated.
-              format: date-time
-              type: string
-            realInjectedNum:
-              description: The number of pods that injected successfully
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The selector label of injected Pod
+      jsonPath: .spec.podSelector
+      name: PodSelector
+      type: string
+    - description: The name of service in the injected agent
+      jsonPath: .spec.serviceName
+      name: ServiceName
+      type: string
+    - description: The backend service in the injected agent
+      jsonPath: .spec.backendService
+      name: BackendService
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: JavaAgent is the Schema for the javaagents API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: JavaAgentSpec defines the desired state of JavaAgent
+            properties:
+              agentConfiguration:
+                additionalProperties:
+                  type: string
+                description: AgentConfiguration is the injected agent's final configuration
+                type: object
+              backendService:
+                description: BackendService is the backend service in the injected
+                  agent, which need to be printed
+                type: string
+              podSelector:
+                description: PodSelector is the selector label of injected Pod
+                type: string
+              serviceName:
+                description: ServiceName is the name of service in the injected agent,
+                  which need to be printed
+                type: string
+            type: object
+          status:
+            description: JavaAgentStatus defines the observed state of JavaAgent
+            properties:
+              creationTime:
+                description: The time the JavaAgent was created.
+                format: date-time
+                type: string
+              expectedInjectiedNum:
+                description: The number of pods that need to be injected
+                type: integer
+              lastUpdateTime:
+                description: The last time this condition was updated.
+                format: date-time
+                type: string
+              realInjectedNum:
+                description: The number of pods that injected successfully
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/dev/operator/crd/bases/operator.skywalking.apache.org_oapservers.yaml
+++ b/config/dev/operator/crd/bases/operator.skywalking.apache.org_oapservers.yaml
@@ -17,36 +17,14 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: oapservers.operator.skywalking.apache.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.version
-    description: The version
-    name: Version
-    priority: 1
-    type: string
-  - JSONPath: .spec.instances
-    description: The number of expected instance
-    name: Instances
-    type: string
-  - JSONPath: .status.availableReplicas
-    description: The number of running
-    name: Running
-    type: string
-  - JSONPath: .status.address
-    description: The address of OAP server
-    name: Address
-    type: string
-  - JSONPath: .spec.image
-    name: Image
-    priority: 1
-    type: string
   group: operator.skywalking.apache.org
   names:
     kind: OAPServer
@@ -54,513 +32,538 @@ spec:
     plural: oapservers
     singular: oapserver
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: OAPServer is the Schema for the oapservers API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: OAPServerSpec defines the desired state of OAPServer
-          properties:
-            config:
-              description: Config holds the OAP server configuration.
-              items:
-                description: EnvVar represents an environment variable present in
-                  a Container.
+  versions:
+  - additionalPrinterColumns:
+    - description: The version
+      jsonPath: .spec.version
+      name: Version
+      priority: 1
+      type: string
+    - description: The number of expected instance
+      jsonPath: .spec.instances
+      name: Instances
+      type: string
+    - description: The number of running
+      jsonPath: .status.availableReplicas
+      name: Running
+      type: string
+    - description: The address of OAP server
+      jsonPath: .status.address
+      name: Address
+      type: string
+    - jsonPath: .spec.image
+      name: Image
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OAPServer is the Schema for the oapservers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OAPServerSpec defines the desired state of OAPServer
+            properties:
+              config:
+                description: Config holds the OAP server configuration.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              image:
+                description: Image is the OAP Server Docker image to deploy.
+                type: string
+              instances:
+                description: Count is the number of OAP servers
+                format: int32
+                type: integer
+              service:
+                description: Service relevant settings
                 properties:
-                  name:
-                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                    type: string
-                  value:
-                    description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
-                      and any service environment variables. If a variable cannot
-                      be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
-                    type: string
-                  valueFrom:
-                    description: Source for the environment variable's value. Cannot
-                      be used if value is not empty.
+                  ingress:
+                    description: Ingress defines the behavior of an ingress
                     properties:
-                      configMapKeyRef:
-                        description: Selects a key of a ConfigMap.
-                        properties:
-                          key:
-                            description: The key to select.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
-                            type: boolean
-                        required:
-                        - key
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects.
                         type: object
-                      fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name,
-                          metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP,
-                          status.podIPs.'
-                        properties:
-                          apiVersion:
-                            description: Version of the schema the FieldPath is written
-                              in terms of, defaults to "v1".
-                            type: string
-                          fieldPath:
-                            description: Path of the field to select in the specified
-                              API version.
-                            type: string
-                        required:
-                        - fieldPath
+                      host:
+                        description: Host is the fully qualified domain name of a
+                          network host, as defined by RFC 3986. Note the following
+                          deviations from the "host" part of the URI as defined in
+                          RFC 3986
+                        type: string
+                      ingressClassName:
+                        description: IngressClassName is the name of the IngressClass
+                          cluster resource. The associated IngressClass defines which
+                          controller will implement the resource. This replaces the
+                          deprecated `kubernetes.io/ingress.class` annotation. For
+                          backwards compatibility, when that annotation is set, it
+                          must be given precedence over this field. The controller
+                          may emit a warning if the field and annotation have different
+                          values. Implementations of this API should ignore Ingresses
+                          without a class specified. An IngressClass resource may
+                          be marked as default, which can be used to set a default
+                          value for this field. For more information, refer to the
+                          IngressClass documentation.
+                        type: string
+                      tls:
+                        description: TLS configuration. Currently the Ingress only
+                          supports a single TLS port, 443. If multiple members of
+                          this list specify different hosts, they will be multiplexed
+                          on the same port according to the hostname specified through
+                          the SNI TLS extension, if the ingress controller fulfilling
+                          the ingress supports SNI.
+                        items:
+                          description: IngressTLS describes the transport layer security
+                            associated with an Ingress.
+                          properties:
+                            hosts:
+                              description: Hosts are a list of hosts included in the
+                                TLS certificate. The values in this list must match
+                                the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller
+                                fulfilling this Ingress, if left unspecified.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            secretName:
+                              description: SecretName is the name of the secret used
+                                to terminate TLS traffic on port 443. Field is left
+                                optional to allow TLS routing based on SNI hostname
+                                alone. If the SNI host in a listener conflicts with
+                                the "Host" header field used by an IngressRule, the
+                                SNI host is used for termination and value of the
+                                Host header is used for routing.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  template:
+                    description: ServiceTemplate defines the behavior of a service.
+                    properties:
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.
+                        items:
+                          type: string
+                        type: array
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs.
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: type determines how the Service is exposed.
+                        type: string
+                    type: object
+                type: object
+              storage:
+                description: StorageConfig relevant settings
+                properties:
+                  injectstorage:
+                    description: Storage relevant settings
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      metadata:
                         type: object
-                      resourceFieldRef:
-                        description: 'Selects a resource of the container: only resources
-                          limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage,
-                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                          are currently supported.'
+                      spec:
+                        description: StorageSpec defines the desired state of Storage
                         properties:
-                          containerName:
-                            description: 'Container name: required for volumes, optional
-                              for env vars'
+                          address:
+                            description: Address of external storage address.
                             type: string
-                          divisor:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Specifies the output format of the exposed
-                              resources, defaults to "1"
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                          config:
+                            description: Config holds the Storage configuration.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previous defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    The $(VAR_NAME) syntax can be escaped with a double
+                                    $$, ie: $$(VAR_NAME). Escaped references will
+                                    never be expanded, regardless of whether the variable
+                                    exists or not. Defaults to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          connectType:
+                            description: ConnectType is the way to connect storage(e.g.
+                              external,internal).
+                            type: string
+                          image:
+                            description: Image is the storage Docker image to deploy.
+                            type: string
+                          instances:
+                            description: Instance is the number of storage.
+                            format: int32
+                            type: integer
                           resource:
-                            description: 'Required: resource to select'
+                            description: ResourceCnfig relevant settings
+                            properties:
+                              limit:
+                                type: string
+                              requests:
+                                type: string
+                            type: object
+                          security:
+                            description: Security relevant settings
+                            properties:
+                              tls:
+                                description: SSLConfig of  storage .
+                                type: boolean
+                              user:
+                                description: UserConfig of storage .
+                                properties:
+                                  secretName:
+                                    description: SecretName of storage user .
+                                    type: string
+                                type: object
+                            type: object
+                          servicename:
+                            description: ServiceName relevant settings
                             type: string
-                        required:
-                        - resource
+                          type:
+                            description: Type of storage.
+                            type: string
+                          version:
+                            description: Version of storage.
+                            type: string
                         type: object
-                      secretKeyRef:
-                        description: Selects a key of a secret in the pod's namespace
+                      status:
+                        description: StorageStatus defines the observed state of Storage
                         properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
+                          conditions:
+                            description: Represents the latest available observations
+                              of the underlying statefulset's current state.
+                            items:
+                              description: StatefulSetCondition describes the state
+                                of a statefulset at a certain point.
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned
+                                    from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: A human readable message indicating
+                                    details about the transition.
+                                  type: string
+                                reason:
+                                  description: The reason for the condition's last
+                                    transition.
+                                  type: string
+                                status:
+                                  description: Status of the condition, one of True,
+                                    False, Unknown.
+                                  type: string
+                                type:
+                                  description: Type of statefulset condition.
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
                         type: object
                     type: object
-                required:
-                - name
+                  name:
+                    description: Name relevant settings
+                    type: string
                 type: object
-              type: array
-            image:
-              description: Image is the OAP Server Docker image to deploy.
-              type: string
-            instances:
-              description: Count is the number of OAP servers
-              format: int32
-              type: integer
-            service:
-              description: Service relevant settings
-              properties:
-                ingress:
-                  description: Ingress defines the behavior of an ingress
+              version:
+                description: Version of OAP.
+                type: string
+            required:
+            - instances
+            - version
+            type: object
+          status:
+            description: OAPServerStatus defines the observed state of OAPServer
+            properties:
+              address:
+                description: Address indicates the entry of OAP server which ingresses
+                  data
+                type: string
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of the underlying
+                  deployment's current state.
+                items:
+                  description: DeploymentCondition describes the state of a deployment
+                    at a certain point.
                   properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is an unstructured key value map stored
-                        with a resource that may be set by external tools to store
-                        and retrieve arbitrary metadata. They are not queryable and
-                        should be preserved when modifying objects.
-                      type: object
-                    host:
-                      description: Host is the fully qualified domain name of a network
-                        host, as defined by RFC 3986. Note the following deviations
-                        from the "host" part of the URI as defined in RFC 3986
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
                       type: string
-                    ingressClassName:
-                      description: IngressClassName is the name of the IngressClass
-                        cluster resource. The associated IngressClass defines which
-                        controller will implement the resource. This replaces the
-                        deprecated `kubernetes.io/ingress.class` annotation. For backwards
-                        compatibility, when that annotation is set, it must be given
-                        precedence over this field. The controller may emit a warning
-                        if the field and annotation have different values. Implementations
-                        of this API should ignore Ingresses without a class specified.
-                        An IngressClass resource may be marked as default, which can
-                        be used to set a default value for this field. For more information,
-                        refer to the IngressClass documentation.
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
                       type: string
-                    tls:
-                      description: TLS configuration. Currently the Ingress only supports
-                        a single TLS port, 443. If multiple members of this list specify
-                        different hosts, they will be multiplexed on the same port
-                        according to the hostname specified through the SNI TLS extension,
-                        if the ingress controller fulfilling the ingress supports
-                        SNI.
-                      items:
-                        description: IngressTLS describes the transport layer security
-                          associated with an Ingress.
-                        properties:
-                          hosts:
-                            description: Hosts are a list of hosts included in the
-                              TLS certificate. The values in this list must match
-                              the name/s used in the tlsSecret. Defaults to the wildcard
-                              host setting for the loadbalancer controller fulfilling
-                              this Ingress, if left unspecified.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          secretName:
-                            description: SecretName is the name of the secret used
-                              to terminate TLS traffic on port 443. Field is left
-                              optional to allow TLS routing based on SNI hostname
-                              alone. If the SNI host in a listener conflicts with
-                              the "Host" header field used by an IngressRule, the
-                              SNI host is used for termination and value of the Host
-                              header is used for routing.
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                template:
-                  description: ServiceTemplate defines the behavior of a service.
-                  properties:
-                    clusterIP:
-                      description: clusterIP is the IP address of the service and
-                        is usually assigned randomly.
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.
-                      items:
-                        type: string
-                      type: array
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field.'
+                    reason:
+                      description: The reason for the condition's last transition.
                       type: string
-                    loadBalancerSourceRanges:
-                      description: If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs.
-                      items:
-                        type: string
-                      type: array
-                    type:
-                      description: type determines how the Service is exposed.
-                      type: string
-                  type: object
-              type: object
-            storage:
-              description: StorageConfig relevant settings
-              properties:
-                injectstorage:
-                  description: Storage relevant settings
-                  properties:
-                    apiVersion:
-                      description: 'APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                      type: string
-                    kind:
-                      description: 'Kind is a string value representing the REST resource
-                        this object represents. Servers may infer this from the endpoint
-                        the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    metadata:
-                      type: object
-                    spec:
-                      description: StorageSpec defines the desired state of Storage
-                      properties:
-                        address:
-                          description: Address of external storage address.
-                          type: string
-                        config:
-                          description: Config holds the Storage configuration.
-                          items:
-                            description: EnvVar represents an environment variable
-                              present in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's
-                                  value. Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap
-                                          or its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the
-                                      pod's namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        connectType:
-                          description: ConnectType is the way to connect storage(e.g.
-                            external,internal).
-                          type: string
-                        image:
-                          description: Image is the storage Docker image to deploy.
-                          type: string
-                        instances:
-                          description: Instance is the number of storage.
-                          format: int32
-                          type: integer
-                        resource:
-                          description: ResourceCnfig relevant settings
-                          properties:
-                            limit:
-                              type: string
-                            requests:
-                              type: string
-                          type: object
-                        security:
-                          description: Security relevant settings
-                          properties:
-                            tls:
-                              description: SSLConfig of  storage .
-                              type: boolean
-                            user:
-                              description: UserConfig of storage .
-                              properties:
-                                secretName:
-                                  description: SecretName of storage user .
-                                  type: string
-                              type: object
-                          type: object
-                        servicename:
-                          description: ServiceName relevant settings
-                          type: string
-                        type:
-                          description: Type of storage.
-                          type: string
-                        version:
-                          description: Version of storage.
-                          type: string
-                      type: object
                     status:
-                      description: StorageStatus defines the observed state of Storage
-                      properties:
-                        conditions:
-                          description: Represents the latest available observations
-                            of the underlying statefulset's current state.
-                          items:
-                            description: StatefulSetCondition describes the state
-                              of a statefulset at a certain point.
-                            properties:
-                              lastTransitionTime:
-                                description: Last time the condition transitioned
-                                  from one status to another.
-                                format: date-time
-                                type: string
-                              message:
-                                description: A human readable message indicating details
-                                  about the transition.
-                                type: string
-                              reason:
-                                description: The reason for the condition's last transition.
-                                type: string
-                              status:
-                                description: Status of the condition, one of True,
-                                  False, Unknown.
-                                type: string
-                              type:
-                                description: Type of statefulset condition.
-                                type: string
-                            required:
-                            - status
-                            - type
-                            type: object
-                          type: array
-                      type: object
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of deployment condition.
+                      type: string
+                  required:
+                  - status
+                  - type
                   type: object
-                name:
-                  description: Name relevant settings
-                  type: string
-              type: object
-            version:
-              description: Version of OAP.
-              type: string
-          required:
-          - instances
-          - version
-          type: object
-        status:
-          description: OAPServerStatus defines the observed state of OAPServer
-          properties:
-            address:
-              description: Address indicates the entry of OAP server which ingresses
-                data
-              type: string
-            availableReplicas:
-              description: Total number of available pods (ready for at least minReadySeconds)
-                targeted by this deployment.
-              format: int32
-              type: integer
-            conditions:
-              description: Represents the latest available observations of the underlying
-                deployment's current state.
-              items:
-                description: DeploymentCondition describes the state of a deployment
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of deployment condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/dev/operator/crd/bases/operator.skywalking.apache.org_storages.yaml
+++ b/config/dev/operator/crd/bases/operator.skywalking.apache.org_storages.yaml
@@ -17,31 +17,14 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: storages.operator.skywalking.apache.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.instances
-    description: The number of expected instance
-    name: Instances
-    type: string
-  - JSONPath: .spec.type
-    description: The type of storage
-    name: Type
-    type: string
-  - JSONPath: .spec.version
-    description: The version
-    name: Version
-    type: string
-  - JSONPath: .spec.connectType
-    description: the way to connect storage
-    name: ConnectType
-    type: string
   group: operator.skywalking.apache.org
   names:
     kind: Storage
@@ -49,215 +32,231 @@ spec:
     plural: storages
     singular: storage
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Storage is the Schema for the storages API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: StorageSpec defines the desired state of Storage
-          properties:
-            address:
-              description: Address of external storage address.
-              type: string
-            config:
-              description: Config holds the Storage configuration.
-              items:
-                description: EnvVar represents an environment variable present in
-                  a Container.
-                properties:
-                  name:
-                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                    type: string
-                  value:
-                    description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
-                      and any service environment variables. If a variable cannot
-                      be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
-                    type: string
-                  valueFrom:
-                    description: Source for the environment variable's value. Cannot
-                      be used if value is not empty.
-                    properties:
-                      configMapKeyRef:
-                        description: Selects a key of a ConfigMap.
-                        properties:
-                          key:
-                            description: The key to select.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                      fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name,
-                          metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP,
-                          status.podIPs.'
-                        properties:
-                          apiVersion:
-                            description: Version of the schema the FieldPath is written
-                              in terms of, defaults to "v1".
-                            type: string
-                          fieldPath:
-                            description: Path of the field to select in the specified
-                              API version.
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      resourceFieldRef:
-                        description: 'Selects a resource of the container: only resources
-                          limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage,
-                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                          are currently supported.'
-                        properties:
-                          containerName:
-                            description: 'Container name: required for volumes, optional
-                              for env vars'
-                            type: string
-                          divisor:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Specifies the output format of the exposed
-                              resources, defaults to "1"
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          resource:
-                            description: 'Required: resource to select'
-                            type: string
-                        required:
-                        - resource
-                        type: object
-                      secretKeyRef:
-                        description: Selects a key of a secret in the pod's namespace
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            connectType:
-              description: ConnectType is the way to connect storage(e.g. external,internal).
-              type: string
-            image:
-              description: Image is the storage Docker image to deploy.
-              type: string
-            instances:
-              description: Instance is the number of storage.
-              format: int32
-              type: integer
-            resource:
-              description: ResourceCnfig relevant settings
-              properties:
-                limit:
-                  type: string
-                requests:
-                  type: string
-              type: object
-            security:
-              description: Security relevant settings
-              properties:
-                tls:
-                  description: SSLConfig of  storage .
-                  type: boolean
-                user:
-                  description: UserConfig of storage .
-                  properties:
-                    secretName:
-                      description: SecretName of storage user .
-                      type: string
-                  type: object
-              type: object
-            servicename:
-              description: ServiceName relevant settings
-              type: string
-            type:
-              description: Type of storage.
-              type: string
-            version:
-              description: Version of storage.
-              type: string
-          type: object
-        status:
-          description: StorageStatus defines the observed state of Storage
-          properties:
-            conditions:
-              description: Represents the latest available observations of the underlying
-                statefulset's current state.
-              items:
-                description: StatefulSetCondition describes the state of a statefulset
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of statefulset condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The number of expected instance
+      jsonPath: .spec.instances
+      name: Instances
+      type: string
+    - description: The type of storage
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: The version
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: the way to connect storage
+      jsonPath: .spec.connectType
+      name: ConnectType
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Storage is the Schema for the storages API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StorageSpec defines the desired state of Storage
+            properties:
+              address:
+                description: Address of external storage address.
+                type: string
+              config:
+                description: Config holds the Storage configuration.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              connectType:
+                description: ConnectType is the way to connect storage(e.g. external,internal).
+                type: string
+              image:
+                description: Image is the storage Docker image to deploy.
+                type: string
+              instances:
+                description: Instance is the number of storage.
+                format: int32
+                type: integer
+              resource:
+                description: ResourceCnfig relevant settings
+                properties:
+                  limit:
+                    type: string
+                  requests:
+                    type: string
+                type: object
+              security:
+                description: Security relevant settings
+                properties:
+                  tls:
+                    description: SSLConfig of  storage .
+                    type: boolean
+                  user:
+                    description: UserConfig of storage .
+                    properties:
+                      secretName:
+                        description: SecretName of storage user .
+                        type: string
+                    type: object
+                type: object
+              servicename:
+                description: ServiceName relevant settings
+                type: string
+              type:
+                description: Type of storage.
+                type: string
+              version:
+                description: Version of storage.
+                type: string
+            type: object
+          status:
+            description: StorageStatus defines the observed state of Storage
+            properties:
+              conditions:
+                description: Represents the latest available observations of the underlying
+                  statefulset's current state.
+                items:
+                  description: StatefulSetCondition describes the state of a statefulset
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of statefulset condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/dev/operator/crd/bases/operator.skywalking.apache.org_uis.yaml
+++ b/config/dev/operator/crd/bases/operator.skywalking.apache.org_uis.yaml
@@ -17,44 +17,14 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: uis.operator.skywalking.apache.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.version
-    description: The version
-    name: Version
-    priority: 1
-    type: string
-  - JSONPath: .spec.instances
-    description: The number of expected instance
-    name: Instances
-    type: string
-  - JSONPath: .status.availableReplicas
-    description: The number of running
-    name: Running
-    type: string
-  - JSONPath: .status.internalAddress
-    description: The address of OAP server
-    name: InternalAddress
-    type: string
-  - JSONPath: .status.externalIPs
-    description: The address of OAP server
-    name: ExternalIPs
-    type: string
-  - JSONPath: .status.ports
-    description: The address of OAP server
-    name: Ports
-    type: string
-  - JSONPath: .spec.image
-    name: Image
-    priority: 1
-    type: string
   group: operator.skywalking.apache.org
   names:
     kind: UI
@@ -62,201 +32,232 @@ spec:
     plural: uis
     singular: ui
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: UI is the Schema for the uis API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: UISpec defines the desired state of UI
-          properties:
-            OAPServerAddress:
-              description: Backend OAP server address
-              type: string
-            image:
-              description: Image is the UI Docker image to deploy.
-              type: string
-            instances:
-              description: Count is the number of UI pods
-              format: int32
-              type: integer
-            service:
-              description: Service relevant settings
-              properties:
-                ingress:
-                  description: Ingress defines the behavior of an ingress
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is an unstructured key value map stored
-                        with a resource that may be set by external tools to store
-                        and retrieve arbitrary metadata. They are not queryable and
-                        should be preserved when modifying objects.
-                      type: object
-                    host:
-                      description: Host is the fully qualified domain name of a network
-                        host, as defined by RFC 3986. Note the following deviations
-                        from the "host" part of the URI as defined in RFC 3986
-                      type: string
-                    ingressClassName:
-                      description: IngressClassName is the name of the IngressClass
-                        cluster resource. The associated IngressClass defines which
-                        controller will implement the resource. This replaces the
-                        deprecated `kubernetes.io/ingress.class` annotation. For backwards
-                        compatibility, when that annotation is set, it must be given
-                        precedence over this field. The controller may emit a warning
-                        if the field and annotation have different values. Implementations
-                        of this API should ignore Ingresses without a class specified.
-                        An IngressClass resource may be marked as default, which can
-                        be used to set a default value for this field. For more information,
-                        refer to the IngressClass documentation.
-                      type: string
-                    tls:
-                      description: TLS configuration. Currently the Ingress only supports
-                        a single TLS port, 443. If multiple members of this list specify
-                        different hosts, they will be multiplexed on the same port
-                        according to the hostname specified through the SNI TLS extension,
-                        if the ingress controller fulfilling the ingress supports
-                        SNI.
-                      items:
-                        description: IngressTLS describes the transport layer security
-                          associated with an Ingress.
-                        properties:
-                          hosts:
-                            description: Hosts are a list of hosts included in the
-                              TLS certificate. The values in this list must match
-                              the name/s used in the tlsSecret. Defaults to the wildcard
-                              host setting for the loadbalancer controller fulfilling
-                              this Ingress, if left unspecified.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          secretName:
-                            description: SecretName is the name of the secret used
-                              to terminate TLS traffic on port 443. Field is left
-                              optional to allow TLS routing based on SNI hostname
-                              alone. If the SNI host in a listener conflicts with
-                              the "Host" header field used by an IngressRule, the
-                              SNI host is used for termination and value of the Host
-                              header is used for routing.
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                template:
-                  description: ServiceTemplate defines the behavior of a service.
-                  properties:
-                    clusterIP:
-                      description: clusterIP is the IP address of the service and
-                        is usually assigned randomly.
-                      type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.
-                      items:
-                        type: string
-                      type: array
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field.'
-                      type: string
-                    loadBalancerSourceRanges:
-                      description: If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs.
-                      items:
-                        type: string
-                      type: array
-                    type:
-                      description: type determines how the Service is exposed.
-                      type: string
-                  type: object
-              type: object
-            version:
-              description: Version of UI.
-              type: string
-          required:
-          - instances
-          - version
-          type: object
-        status:
-          description: UIStatus defines the observed state of UI
-          properties:
-            availableReplicas:
-              description: Total number of available pods (ready for at least minReadySeconds)
-                targeted by this deployment.
-              format: int32
-              type: integer
-            conditions:
-              description: Represents the latest available observations of the underlying
-                deployment's current state.
-              items:
-                description: DeploymentCondition describes the state of a deployment
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of deployment condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            externalIPs:
-              description: externalIPs is a list of IP addresses for which nodes in
-                the cluster will also accept traffic for this service.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The version
+      jsonPath: .spec.version
+      name: Version
+      priority: 1
+      type: string
+    - description: The number of expected instance
+      jsonPath: .spec.instances
+      name: Instances
+      type: string
+    - description: The number of running
+      jsonPath: .status.availableReplicas
+      name: Running
+      type: string
+    - description: The address of OAP server
+      jsonPath: .status.internalAddress
+      name: InternalAddress
+      type: string
+    - description: The address of OAP server
+      jsonPath: .status.externalIPs
+      name: ExternalIPs
+      type: string
+    - description: The address of OAP server
+      jsonPath: .status.ports
+      name: Ports
+      type: string
+    - jsonPath: .spec.image
+      name: Image
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: UI is the Schema for the uis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UISpec defines the desired state of UI
+            properties:
+              OAPServerAddress:
+                description: Backend OAP server address
                 type: string
-              type: array
-            internalAddress:
-              type: string
-            ports:
-              description: Ports that will be exposed by this service.
-              items:
+              image:
+                description: Image is the UI Docker image to deploy.
+                type: string
+              instances:
+                description: Count is the number of UI pods
                 format: int32
                 type: integer
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              service:
+                description: Service relevant settings
+                properties:
+                  ingress:
+                    description: Ingress defines the behavior of an ingress
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects.
+                        type: object
+                      host:
+                        description: Host is the fully qualified domain name of a
+                          network host, as defined by RFC 3986. Note the following
+                          deviations from the "host" part of the URI as defined in
+                          RFC 3986
+                        type: string
+                      ingressClassName:
+                        description: IngressClassName is the name of the IngressClass
+                          cluster resource. The associated IngressClass defines which
+                          controller will implement the resource. This replaces the
+                          deprecated `kubernetes.io/ingress.class` annotation. For
+                          backwards compatibility, when that annotation is set, it
+                          must be given precedence over this field. The controller
+                          may emit a warning if the field and annotation have different
+                          values. Implementations of this API should ignore Ingresses
+                          without a class specified. An IngressClass resource may
+                          be marked as default, which can be used to set a default
+                          value for this field. For more information, refer to the
+                          IngressClass documentation.
+                        type: string
+                      tls:
+                        description: TLS configuration. Currently the Ingress only
+                          supports a single TLS port, 443. If multiple members of
+                          this list specify different hosts, they will be multiplexed
+                          on the same port according to the hostname specified through
+                          the SNI TLS extension, if the ingress controller fulfilling
+                          the ingress supports SNI.
+                        items:
+                          description: IngressTLS describes the transport layer security
+                            associated with an Ingress.
+                          properties:
+                            hosts:
+                              description: Hosts are a list of hosts included in the
+                                TLS certificate. The values in this list must match
+                                the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller
+                                fulfilling this Ingress, if left unspecified.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            secretName:
+                              description: SecretName is the name of the secret used
+                                to terminate TLS traffic on port 443. Field is left
+                                optional to allow TLS routing based on SNI hostname
+                                alone. If the SNI host in a listener conflicts with
+                                the "Host" header field used by an IngressRule, the
+                                SNI host is used for termination and value of the
+                                Host header is used for routing.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  template:
+                    description: ServiceTemplate defines the behavior of a service.
+                    properties:
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.
+                        items:
+                          type: string
+                        type: array
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs.
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: type determines how the Service is exposed.
+                        type: string
+                    type: object
+                type: object
+              version:
+                description: Version of UI.
+                type: string
+            required:
+            - instances
+            - version
+            type: object
+          status:
+            description: UIStatus defines the observed state of UI
+            properties:
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of the underlying
+                  deployment's current state.
+                items:
+                  description: DeploymentCondition describes the state of a deployment
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of deployment condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalIPs:
+                description: externalIPs is a list of IP addresses for which nodes
+                  in the cluster will also accept traffic for this service.
+                items:
+                  type: string
+                type: array
+              internalAddress:
+                type: string
+              ports:
+                description: Ports that will be exposed by this service.
+                items:
+                  format: int32
+                  type: integer
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/operator/certmanager/certificate.yaml
+++ b/config/operator/certmanager/certificate.yaml
@@ -19,7 +19,7 @@
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
 # breaking changes
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -27,7 +27,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/config/operator/crd/bases/operator.skywalking.apache.org_fetchers.yaml
+++ b/config/operator/crd/bases/operator.skywalking.apache.org_fetchers.yaml
@@ -17,11 +17,11 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: fetchers.operator.skywalking.apache.org
 spec:
@@ -32,86 +32,86 @@ spec:
     plural: fetchers
     singular: fetcher
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Fetcher is the Schema for the fetchers API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: FetcherSpec defines the desired state of Fetcher
-          properties:
-            OAPServerAddress:
-              description: OAPServerAddress is the address of backend OAPServers
-              type: string
-            clusterName:
-              description: ClusterName
-              type: string
-            type:
-              description: Fetcher is the type of how to fetch metrics from target.
-              items:
-                description: Service Type string describes ingress methods for a service
-                type: string
-              type: array
-          type: object
-        status:
-          description: FetcherStatus defines the observed state of Fetcher
-          properties:
-            conditions:
-              description: Represents the latest available observations of a fetcher's
-                current state.
-              items:
-                description: DeploymentCondition describes the state of a deployment
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of deployment condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            replicas:
-              description: Replicas is currently not being set and might be removed
-                in the next version.
-              format: int32
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Fetcher is the Schema for the fetchers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FetcherSpec defines the desired state of Fetcher
+            properties:
+              OAPServerAddress:
+                description: OAPServerAddress is the address of backend OAPServers
+                type: string
+              clusterName:
+                description: ClusterName
+                type: string
+              type:
+                description: Fetcher is the type of how to fetch metrics from target.
+                items:
+                  description: Service Type string describes ingress methods for a
+                    service
+                  type: string
+                type: array
+            type: object
+          status:
+            description: FetcherStatus defines the observed state of Fetcher
+            properties:
+              conditions:
+                description: Represents the latest available observations of a fetcher's
+                  current state.
+                items:
+                  description: DeploymentCondition describes the state of a deployment
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of deployment condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              replicas:
+                description: Replicas is currently not being set and might be removed
+                  in the next version.
+                format: int32
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/operator/crd/bases/operator.skywalking.apache.org_javaagents.yaml
+++ b/config/operator/crd/bases/operator.skywalking.apache.org_javaagents.yaml
@@ -17,27 +17,14 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: javaagents.operator.skywalking.apache.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.podSelector
-    description: The selector label of injected Pod
-    name: PodSelector
-    type: string
-  - JSONPath: .spec.serviceName
-    description: The name of service in the injected agent
-    name: ServiceName
-    type: string
-  - JSONPath: .spec.backendService
-    description: The backend service in the injected agent
-    name: BackendService
-    type: string
   group: operator.skywalking.apache.org
   names:
     kind: JavaAgent
@@ -45,68 +32,80 @@ spec:
     plural: javaagents
     singular: javaagent
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: JavaAgent is the Schema for the javaagents API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: JavaAgentSpec defines the desired state of JavaAgent
-          properties:
-            agentConfiguration:
-              additionalProperties:
-                type: string
-              description: AgentConfiguration is the injected agent's final configuration
-              type: object
-            backendService:
-              description: BackendService is the backend service in the injected agent,
-                which need to be printed
-              type: string
-            podSelector:
-              description: PodSelector is the selector label of injected Pod
-              type: string
-            serviceName:
-              description: ServiceName is the name of service in the injected agent,
-                which need to be printed
-              type: string
-          type: object
-        status:
-          description: JavaAgentStatus defines the observed state of JavaAgent
-          properties:
-            creationTime:
-              description: The time the JavaAgent was created.
-              format: date-time
-              type: string
-            expectedInjectiedNum:
-              description: The number of pods that need to be injected
-              type: integer
-            lastUpdateTime:
-              description: The last time this condition was updated.
-              format: date-time
-              type: string
-            realInjectedNum:
-              description: The number of pods that injected successfully
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The selector label of injected Pod
+      jsonPath: .spec.podSelector
+      name: PodSelector
+      type: string
+    - description: The name of service in the injected agent
+      jsonPath: .spec.serviceName
+      name: ServiceName
+      type: string
+    - description: The backend service in the injected agent
+      jsonPath: .spec.backendService
+      name: BackendService
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: JavaAgent is the Schema for the javaagents API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: JavaAgentSpec defines the desired state of JavaAgent
+            properties:
+              agentConfiguration:
+                additionalProperties:
+                  type: string
+                description: AgentConfiguration is the injected agent's final configuration
+                type: object
+              backendService:
+                description: BackendService is the backend service in the injected
+                  agent, which need to be printed
+                type: string
+              podSelector:
+                description: PodSelector is the selector label of injected Pod
+                type: string
+              serviceName:
+                description: ServiceName is the name of service in the injected agent,
+                  which need to be printed
+                type: string
+            type: object
+          status:
+            description: JavaAgentStatus defines the observed state of JavaAgent
+            properties:
+              creationTime:
+                description: The time the JavaAgent was created.
+                format: date-time
+                type: string
+              expectedInjectiedNum:
+                description: The number of pods that need to be injected
+                type: integer
+              lastUpdateTime:
+                description: The last time this condition was updated.
+                format: date-time
+                type: string
+              realInjectedNum:
+                description: The number of pods that injected successfully
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/operator/crd/bases/operator.skywalking.apache.org_oapservers.yaml
+++ b/config/operator/crd/bases/operator.skywalking.apache.org_oapservers.yaml
@@ -17,36 +17,14 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: oapservers.operator.skywalking.apache.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.version
-    description: The version
-    name: Version
-    priority: 1
-    type: string
-  - JSONPath: .spec.instances
-    description: The number of expected instance
-    name: Instances
-    type: string
-  - JSONPath: .status.availableReplicas
-    description: The number of running
-    name: Running
-    type: string
-  - JSONPath: .status.address
-    description: The address of OAP server
-    name: Address
-    type: string
-  - JSONPath: .spec.image
-    name: Image
-    priority: 1
-    type: string
   group: operator.skywalking.apache.org
   names:
     kind: OAPServer
@@ -54,513 +32,538 @@ spec:
     plural: oapservers
     singular: oapserver
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: OAPServer is the Schema for the oapservers API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: OAPServerSpec defines the desired state of OAPServer
-          properties:
-            config:
-              description: Config holds the OAP server configuration.
-              items:
-                description: EnvVar represents an environment variable present in
-                  a Container.
+  versions:
+  - additionalPrinterColumns:
+    - description: The version
+      jsonPath: .spec.version
+      name: Version
+      priority: 1
+      type: string
+    - description: The number of expected instance
+      jsonPath: .spec.instances
+      name: Instances
+      type: string
+    - description: The number of running
+      jsonPath: .status.availableReplicas
+      name: Running
+      type: string
+    - description: The address of OAP server
+      jsonPath: .status.address
+      name: Address
+      type: string
+    - jsonPath: .spec.image
+      name: Image
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OAPServer is the Schema for the oapservers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OAPServerSpec defines the desired state of OAPServer
+            properties:
+              config:
+                description: Config holds the OAP server configuration.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              image:
+                description: Image is the OAP Server Docker image to deploy.
+                type: string
+              instances:
+                description: Count is the number of OAP servers
+                format: int32
+                type: integer
+              service:
+                description: Service relevant settings
                 properties:
-                  name:
-                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                    type: string
-                  value:
-                    description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
-                      and any service environment variables. If a variable cannot
-                      be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
-                    type: string
-                  valueFrom:
-                    description: Source for the environment variable's value. Cannot
-                      be used if value is not empty.
+                  ingress:
+                    description: Ingress defines the behavior of an ingress
                     properties:
-                      configMapKeyRef:
-                        description: Selects a key of a ConfigMap.
-                        properties:
-                          key:
-                            description: The key to select.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
-                            type: boolean
-                        required:
-                        - key
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects.
                         type: object
-                      fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name,
-                          metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP,
-                          status.podIPs.'
-                        properties:
-                          apiVersion:
-                            description: Version of the schema the FieldPath is written
-                              in terms of, defaults to "v1".
-                            type: string
-                          fieldPath:
-                            description: Path of the field to select in the specified
-                              API version.
-                            type: string
-                        required:
-                        - fieldPath
+                      host:
+                        description: Host is the fully qualified domain name of a
+                          network host, as defined by RFC 3986. Note the following
+                          deviations from the "host" part of the URI as defined in
+                          RFC 3986
+                        type: string
+                      ingressClassName:
+                        description: IngressClassName is the name of the IngressClass
+                          cluster resource. The associated IngressClass defines which
+                          controller will implement the resource. This replaces the
+                          deprecated `kubernetes.io/ingress.class` annotation. For
+                          backwards compatibility, when that annotation is set, it
+                          must be given precedence over this field. The controller
+                          may emit a warning if the field and annotation have different
+                          values. Implementations of this API should ignore Ingresses
+                          without a class specified. An IngressClass resource may
+                          be marked as default, which can be used to set a default
+                          value for this field. For more information, refer to the
+                          IngressClass documentation.
+                        type: string
+                      tls:
+                        description: TLS configuration. Currently the Ingress only
+                          supports a single TLS port, 443. If multiple members of
+                          this list specify different hosts, they will be multiplexed
+                          on the same port according to the hostname specified through
+                          the SNI TLS extension, if the ingress controller fulfilling
+                          the ingress supports SNI.
+                        items:
+                          description: IngressTLS describes the transport layer security
+                            associated with an Ingress.
+                          properties:
+                            hosts:
+                              description: Hosts are a list of hosts included in the
+                                TLS certificate. The values in this list must match
+                                the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller
+                                fulfilling this Ingress, if left unspecified.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            secretName:
+                              description: SecretName is the name of the secret used
+                                to terminate TLS traffic on port 443. Field is left
+                                optional to allow TLS routing based on SNI hostname
+                                alone. If the SNI host in a listener conflicts with
+                                the "Host" header field used by an IngressRule, the
+                                SNI host is used for termination and value of the
+                                Host header is used for routing.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  template:
+                    description: ServiceTemplate defines the behavior of a service.
+                    properties:
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.
+                        items:
+                          type: string
+                        type: array
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs.
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: type determines how the Service is exposed.
+                        type: string
+                    type: object
+                type: object
+              storage:
+                description: StorageConfig relevant settings
+                properties:
+                  injectstorage:
+                    description: Storage relevant settings
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      metadata:
                         type: object
-                      resourceFieldRef:
-                        description: 'Selects a resource of the container: only resources
-                          limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage,
-                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                          are currently supported.'
+                      spec:
+                        description: StorageSpec defines the desired state of Storage
                         properties:
-                          containerName:
-                            description: 'Container name: required for volumes, optional
-                              for env vars'
+                          address:
+                            description: Address of external storage address.
                             type: string
-                          divisor:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Specifies the output format of the exposed
-                              resources, defaults to "1"
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                          config:
+                            description: Config holds the Storage configuration.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previous defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    The $(VAR_NAME) syntax can be escaped with a double
+                                    $$, ie: $$(VAR_NAME). Escaped references will
+                                    never be expanded, regardless of whether the variable
+                                    exists or not. Defaults to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          connectType:
+                            description: ConnectType is the way to connect storage(e.g.
+                              external,internal).
+                            type: string
+                          image:
+                            description: Image is the storage Docker image to deploy.
+                            type: string
+                          instances:
+                            description: Instance is the number of storage.
+                            format: int32
+                            type: integer
                           resource:
-                            description: 'Required: resource to select'
+                            description: ResourceCnfig relevant settings
+                            properties:
+                              limit:
+                                type: string
+                              requests:
+                                type: string
+                            type: object
+                          security:
+                            description: Security relevant settings
+                            properties:
+                              tls:
+                                description: SSLConfig of  storage .
+                                type: boolean
+                              user:
+                                description: UserConfig of storage .
+                                properties:
+                                  secretName:
+                                    description: SecretName of storage user .
+                                    type: string
+                                type: object
+                            type: object
+                          servicename:
+                            description: ServiceName relevant settings
                             type: string
-                        required:
-                        - resource
+                          type:
+                            description: Type of storage.
+                            type: string
+                          version:
+                            description: Version of storage.
+                            type: string
                         type: object
-                      secretKeyRef:
-                        description: Selects a key of a secret in the pod's namespace
+                      status:
+                        description: StorageStatus defines the observed state of Storage
                         properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
+                          conditions:
+                            description: Represents the latest available observations
+                              of the underlying statefulset's current state.
+                            items:
+                              description: StatefulSetCondition describes the state
+                                of a statefulset at a certain point.
+                              properties:
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned
+                                    from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: A human readable message indicating
+                                    details about the transition.
+                                  type: string
+                                reason:
+                                  description: The reason for the condition's last
+                                    transition.
+                                  type: string
+                                status:
+                                  description: Status of the condition, one of True,
+                                    False, Unknown.
+                                  type: string
+                                type:
+                                  description: Type of statefulset condition.
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
                         type: object
                     type: object
-                required:
-                - name
+                  name:
+                    description: Name relevant settings
+                    type: string
                 type: object
-              type: array
-            image:
-              description: Image is the OAP Server Docker image to deploy.
-              type: string
-            instances:
-              description: Count is the number of OAP servers
-              format: int32
-              type: integer
-            service:
-              description: Service relevant settings
-              properties:
-                ingress:
-                  description: Ingress defines the behavior of an ingress
+              version:
+                description: Version of OAP.
+                type: string
+            required:
+            - instances
+            - version
+            type: object
+          status:
+            description: OAPServerStatus defines the observed state of OAPServer
+            properties:
+              address:
+                description: Address indicates the entry of OAP server which ingresses
+                  data
+                type: string
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of the underlying
+                  deployment's current state.
+                items:
+                  description: DeploymentCondition describes the state of a deployment
+                    at a certain point.
                   properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is an unstructured key value map stored
-                        with a resource that may be set by external tools to store
-                        and retrieve arbitrary metadata. They are not queryable and
-                        should be preserved when modifying objects.
-                      type: object
-                    host:
-                      description: Host is the fully qualified domain name of a network
-                        host, as defined by RFC 3986. Note the following deviations
-                        from the "host" part of the URI as defined in RFC 3986
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
                       type: string
-                    ingressClassName:
-                      description: IngressClassName is the name of the IngressClass
-                        cluster resource. The associated IngressClass defines which
-                        controller will implement the resource. This replaces the
-                        deprecated `kubernetes.io/ingress.class` annotation. For backwards
-                        compatibility, when that annotation is set, it must be given
-                        precedence over this field. The controller may emit a warning
-                        if the field and annotation have different values. Implementations
-                        of this API should ignore Ingresses without a class specified.
-                        An IngressClass resource may be marked as default, which can
-                        be used to set a default value for this field. For more information,
-                        refer to the IngressClass documentation.
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
                       type: string
-                    tls:
-                      description: TLS configuration. Currently the Ingress only supports
-                        a single TLS port, 443. If multiple members of this list specify
-                        different hosts, they will be multiplexed on the same port
-                        according to the hostname specified through the SNI TLS extension,
-                        if the ingress controller fulfilling the ingress supports
-                        SNI.
-                      items:
-                        description: IngressTLS describes the transport layer security
-                          associated with an Ingress.
-                        properties:
-                          hosts:
-                            description: Hosts are a list of hosts included in the
-                              TLS certificate. The values in this list must match
-                              the name/s used in the tlsSecret. Defaults to the wildcard
-                              host setting for the loadbalancer controller fulfilling
-                              this Ingress, if left unspecified.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          secretName:
-                            description: SecretName is the name of the secret used
-                              to terminate TLS traffic on port 443. Field is left
-                              optional to allow TLS routing based on SNI hostname
-                              alone. If the SNI host in a listener conflicts with
-                              the "Host" header field used by an IngressRule, the
-                              SNI host is used for termination and value of the Host
-                              header is used for routing.
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                template:
-                  description: ServiceTemplate defines the behavior of a service.
-                  properties:
-                    clusterIP:
-                      description: clusterIP is the IP address of the service and
-                        is usually assigned randomly.
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.
-                      items:
-                        type: string
-                      type: array
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field.'
+                    reason:
+                      description: The reason for the condition's last transition.
                       type: string
-                    loadBalancerSourceRanges:
-                      description: If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs.
-                      items:
-                        type: string
-                      type: array
-                    type:
-                      description: type determines how the Service is exposed.
-                      type: string
-                  type: object
-              type: object
-            storage:
-              description: StorageConfig relevant settings
-              properties:
-                injectstorage:
-                  description: Storage relevant settings
-                  properties:
-                    apiVersion:
-                      description: 'APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                      type: string
-                    kind:
-                      description: 'Kind is a string value representing the REST resource
-                        this object represents. Servers may infer this from the endpoint
-                        the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    metadata:
-                      type: object
-                    spec:
-                      description: StorageSpec defines the desired state of Storage
-                      properties:
-                        address:
-                          description: Address of external storage address.
-                          type: string
-                        config:
-                          description: Config holds the Storage configuration.
-                          items:
-                            description: EnvVar represents an environment variable
-                              present in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's
-                                  value. Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap
-                                          or its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the
-                                      pod's namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        connectType:
-                          description: ConnectType is the way to connect storage(e.g.
-                            external,internal).
-                          type: string
-                        image:
-                          description: Image is the storage Docker image to deploy.
-                          type: string
-                        instances:
-                          description: Instance is the number of storage.
-                          format: int32
-                          type: integer
-                        resource:
-                          description: ResourceCnfig relevant settings
-                          properties:
-                            limit:
-                              type: string
-                            requests:
-                              type: string
-                          type: object
-                        security:
-                          description: Security relevant settings
-                          properties:
-                            tls:
-                              description: SSLConfig of  storage .
-                              type: boolean
-                            user:
-                              description: UserConfig of storage .
-                              properties:
-                                secretName:
-                                  description: SecretName of storage user .
-                                  type: string
-                              type: object
-                          type: object
-                        servicename:
-                          description: ServiceName relevant settings
-                          type: string
-                        type:
-                          description: Type of storage.
-                          type: string
-                        version:
-                          description: Version of storage.
-                          type: string
-                      type: object
                     status:
-                      description: StorageStatus defines the observed state of Storage
-                      properties:
-                        conditions:
-                          description: Represents the latest available observations
-                            of the underlying statefulset's current state.
-                          items:
-                            description: StatefulSetCondition describes the state
-                              of a statefulset at a certain point.
-                            properties:
-                              lastTransitionTime:
-                                description: Last time the condition transitioned
-                                  from one status to another.
-                                format: date-time
-                                type: string
-                              message:
-                                description: A human readable message indicating details
-                                  about the transition.
-                                type: string
-                              reason:
-                                description: The reason for the condition's last transition.
-                                type: string
-                              status:
-                                description: Status of the condition, one of True,
-                                  False, Unknown.
-                                type: string
-                              type:
-                                description: Type of statefulset condition.
-                                type: string
-                            required:
-                            - status
-                            - type
-                            type: object
-                          type: array
-                      type: object
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of deployment condition.
+                      type: string
+                  required:
+                  - status
+                  - type
                   type: object
-                name:
-                  description: Name relevant settings
-                  type: string
-              type: object
-            version:
-              description: Version of OAP.
-              type: string
-          required:
-          - instances
-          - version
-          type: object
-        status:
-          description: OAPServerStatus defines the observed state of OAPServer
-          properties:
-            address:
-              description: Address indicates the entry of OAP server which ingresses
-                data
-              type: string
-            availableReplicas:
-              description: Total number of available pods (ready for at least minReadySeconds)
-                targeted by this deployment.
-              format: int32
-              type: integer
-            conditions:
-              description: Represents the latest available observations of the underlying
-                deployment's current state.
-              items:
-                description: DeploymentCondition describes the state of a deployment
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of deployment condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/operator/crd/bases/operator.skywalking.apache.org_storages.yaml
+++ b/config/operator/crd/bases/operator.skywalking.apache.org_storages.yaml
@@ -17,31 +17,14 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: storages.operator.skywalking.apache.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.instances
-    description: The number of expected instance
-    name: Instances
-    type: string
-  - JSONPath: .spec.type
-    description: The type of storage
-    name: Type
-    type: string
-  - JSONPath: .spec.version
-    description: The version
-    name: Version
-    type: string
-  - JSONPath: .spec.connectType
-    description: the way to connect storage
-    name: ConnectType
-    type: string
   group: operator.skywalking.apache.org
   names:
     kind: Storage
@@ -49,215 +32,231 @@ spec:
     plural: storages
     singular: storage
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Storage is the Schema for the storages API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: StorageSpec defines the desired state of Storage
-          properties:
-            address:
-              description: Address of external storage address.
-              type: string
-            config:
-              description: Config holds the Storage configuration.
-              items:
-                description: EnvVar represents an environment variable present in
-                  a Container.
-                properties:
-                  name:
-                    description: Name of the environment variable. Must be a C_IDENTIFIER.
-                    type: string
-                  value:
-                    description: 'Variable references $(VAR_NAME) are expanded using
-                      the previous defined environment variables in the container
-                      and any service environment variables. If a variable cannot
-                      be resolved, the reference in the input string will be unchanged.
-                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
-                      $$(VAR_NAME). Escaped references will never be expanded, regardless
-                      of whether the variable exists or not. Defaults to "".'
-                    type: string
-                  valueFrom:
-                    description: Source for the environment variable's value. Cannot
-                      be used if value is not empty.
-                    properties:
-                      configMapKeyRef:
-                        description: Selects a key of a ConfigMap.
-                        properties:
-                          key:
-                            description: The key to select.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its key
-                              must be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                      fieldRef:
-                        description: 'Selects a field of the pod: supports metadata.name,
-                          metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP,
-                          status.podIPs.'
-                        properties:
-                          apiVersion:
-                            description: Version of the schema the FieldPath is written
-                              in terms of, defaults to "v1".
-                            type: string
-                          fieldPath:
-                            description: Path of the field to select in the specified
-                              API version.
-                            type: string
-                        required:
-                        - fieldPath
-                        type: object
-                      resourceFieldRef:
-                        description: 'Selects a resource of the container: only resources
-                          limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage,
-                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                          are currently supported.'
-                        properties:
-                          containerName:
-                            description: 'Container name: required for volumes, optional
-                              for env vars'
-                            type: string
-                          divisor:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Specifies the output format of the exposed
-                              resources, defaults to "1"
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          resource:
-                            description: 'Required: resource to select'
-                            type: string
-                        required:
-                        - resource
-                        type: object
-                      secretKeyRef:
-                        description: Selects a key of a secret in the pod's namespace
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            connectType:
-              description: ConnectType is the way to connect storage(e.g. external,internal).
-              type: string
-            image:
-              description: Image is the storage Docker image to deploy.
-              type: string
-            instances:
-              description: Instance is the number of storage.
-              format: int32
-              type: integer
-            resource:
-              description: ResourceCnfig relevant settings
-              properties:
-                limit:
-                  type: string
-                requests:
-                  type: string
-              type: object
-            security:
-              description: Security relevant settings
-              properties:
-                tls:
-                  description: SSLConfig of  storage .
-                  type: boolean
-                user:
-                  description: UserConfig of storage .
-                  properties:
-                    secretName:
-                      description: SecretName of storage user .
-                      type: string
-                  type: object
-              type: object
-            servicename:
-              description: ServiceName relevant settings
-              type: string
-            type:
-              description: Type of storage.
-              type: string
-            version:
-              description: Version of storage.
-              type: string
-          type: object
-        status:
-          description: StorageStatus defines the observed state of Storage
-          properties:
-            conditions:
-              description: Represents the latest available observations of the underlying
-                statefulset's current state.
-              items:
-                description: StatefulSetCondition describes the state of a statefulset
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of statefulset condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The number of expected instance
+      jsonPath: .spec.instances
+      name: Instances
+      type: string
+    - description: The type of storage
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: The version
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: the way to connect storage
+      jsonPath: .spec.connectType
+      name: ConnectType
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Storage is the Schema for the storages API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StorageSpec defines the desired state of Storage
+            properties:
+              address:
+                description: Address of external storage address.
+                type: string
+              config:
+                description: Config holds the Storage configuration.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              connectType:
+                description: ConnectType is the way to connect storage(e.g. external,internal).
+                type: string
+              image:
+                description: Image is the storage Docker image to deploy.
+                type: string
+              instances:
+                description: Instance is the number of storage.
+                format: int32
+                type: integer
+              resource:
+                description: ResourceCnfig relevant settings
+                properties:
+                  limit:
+                    type: string
+                  requests:
+                    type: string
+                type: object
+              security:
+                description: Security relevant settings
+                properties:
+                  tls:
+                    description: SSLConfig of  storage .
+                    type: boolean
+                  user:
+                    description: UserConfig of storage .
+                    properties:
+                      secretName:
+                        description: SecretName of storage user .
+                        type: string
+                    type: object
+                type: object
+              servicename:
+                description: ServiceName relevant settings
+                type: string
+              type:
+                description: Type of storage.
+                type: string
+              version:
+                description: Version of storage.
+                type: string
+            type: object
+          status:
+            description: StorageStatus defines the observed state of Storage
+            properties:
+              conditions:
+                description: Represents the latest available observations of the underlying
+                  statefulset's current state.
+                items:
+                  description: StatefulSetCondition describes the state of a statefulset
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of statefulset condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/operator/crd/bases/operator.skywalking.apache.org_uis.yaml
+++ b/config/operator/crd/bases/operator.skywalking.apache.org_uis.yaml
@@ -17,44 +17,14 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: uis.operator.skywalking.apache.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.version
-    description: The version
-    name: Version
-    priority: 1
-    type: string
-  - JSONPath: .spec.instances
-    description: The number of expected instance
-    name: Instances
-    type: string
-  - JSONPath: .status.availableReplicas
-    description: The number of running
-    name: Running
-    type: string
-  - JSONPath: .status.internalAddress
-    description: The address of OAP server
-    name: InternalAddress
-    type: string
-  - JSONPath: .status.externalIPs
-    description: The address of OAP server
-    name: ExternalIPs
-    type: string
-  - JSONPath: .status.ports
-    description: The address of OAP server
-    name: Ports
-    type: string
-  - JSONPath: .spec.image
-    name: Image
-    priority: 1
-    type: string
   group: operator.skywalking.apache.org
   names:
     kind: UI
@@ -62,201 +32,232 @@ spec:
     plural: uis
     singular: ui
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: UI is the Schema for the uis API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: UISpec defines the desired state of UI
-          properties:
-            OAPServerAddress:
-              description: Backend OAP server address
-              type: string
-            image:
-              description: Image is the UI Docker image to deploy.
-              type: string
-            instances:
-              description: Count is the number of UI pods
-              format: int32
-              type: integer
-            service:
-              description: Service relevant settings
-              properties:
-                ingress:
-                  description: Ingress defines the behavior of an ingress
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations is an unstructured key value map stored
-                        with a resource that may be set by external tools to store
-                        and retrieve arbitrary metadata. They are not queryable and
-                        should be preserved when modifying objects.
-                      type: object
-                    host:
-                      description: Host is the fully qualified domain name of a network
-                        host, as defined by RFC 3986. Note the following deviations
-                        from the "host" part of the URI as defined in RFC 3986
-                      type: string
-                    ingressClassName:
-                      description: IngressClassName is the name of the IngressClass
-                        cluster resource. The associated IngressClass defines which
-                        controller will implement the resource. This replaces the
-                        deprecated `kubernetes.io/ingress.class` annotation. For backwards
-                        compatibility, when that annotation is set, it must be given
-                        precedence over this field. The controller may emit a warning
-                        if the field and annotation have different values. Implementations
-                        of this API should ignore Ingresses without a class specified.
-                        An IngressClass resource may be marked as default, which can
-                        be used to set a default value for this field. For more information,
-                        refer to the IngressClass documentation.
-                      type: string
-                    tls:
-                      description: TLS configuration. Currently the Ingress only supports
-                        a single TLS port, 443. If multiple members of this list specify
-                        different hosts, they will be multiplexed on the same port
-                        according to the hostname specified through the SNI TLS extension,
-                        if the ingress controller fulfilling the ingress supports
-                        SNI.
-                      items:
-                        description: IngressTLS describes the transport layer security
-                          associated with an Ingress.
-                        properties:
-                          hosts:
-                            description: Hosts are a list of hosts included in the
-                              TLS certificate. The values in this list must match
-                              the name/s used in the tlsSecret. Defaults to the wildcard
-                              host setting for the loadbalancer controller fulfilling
-                              this Ingress, if left unspecified.
-                            items:
-                              type: string
-                            type: array
-                            x-kubernetes-list-type: atomic
-                          secretName:
-                            description: SecretName is the name of the secret used
-                              to terminate TLS traffic on port 443. Field is left
-                              optional to allow TLS routing based on SNI hostname
-                              alone. If the SNI host in a listener conflicts with
-                              the "Host" header field used by an IngressRule, the
-                              SNI host is used for termination and value of the Host
-                              header is used for routing.
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                template:
-                  description: ServiceTemplate defines the behavior of a service.
-                  properties:
-                    clusterIP:
-                      description: clusterIP is the IP address of the service and
-                        is usually assigned randomly.
-                      type: string
-                    externalIPs:
-                      description: externalIPs is a list of IP addresses for which
-                        nodes in the cluster will also accept traffic for this service.
-                      items:
-                        type: string
-                      type: array
-                    loadBalancerIP:
-                      description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                        will get created with the IP specified in this field.'
-                      type: string
-                    loadBalancerSourceRanges:
-                      description: If specified and supported by the platform, this
-                        will restrict traffic through the cloud-provider load-balancer
-                        will be restricted to the specified client IPs.
-                      items:
-                        type: string
-                      type: array
-                    type:
-                      description: type determines how the Service is exposed.
-                      type: string
-                  type: object
-              type: object
-            version:
-              description: Version of UI.
-              type: string
-          required:
-          - instances
-          - version
-          type: object
-        status:
-          description: UIStatus defines the observed state of UI
-          properties:
-            availableReplicas:
-              description: Total number of available pods (ready for at least minReadySeconds)
-                targeted by this deployment.
-              format: int32
-              type: integer
-            conditions:
-              description: Represents the latest available observations of the underlying
-                deployment's current state.
-              items:
-                description: DeploymentCondition describes the state of a deployment
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of deployment condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            externalIPs:
-              description: externalIPs is a list of IP addresses for which nodes in
-                the cluster will also accept traffic for this service.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The version
+      jsonPath: .spec.version
+      name: Version
+      priority: 1
+      type: string
+    - description: The number of expected instance
+      jsonPath: .spec.instances
+      name: Instances
+      type: string
+    - description: The number of running
+      jsonPath: .status.availableReplicas
+      name: Running
+      type: string
+    - description: The address of OAP server
+      jsonPath: .status.internalAddress
+      name: InternalAddress
+      type: string
+    - description: The address of OAP server
+      jsonPath: .status.externalIPs
+      name: ExternalIPs
+      type: string
+    - description: The address of OAP server
+      jsonPath: .status.ports
+      name: Ports
+      type: string
+    - jsonPath: .spec.image
+      name: Image
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: UI is the Schema for the uis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UISpec defines the desired state of UI
+            properties:
+              OAPServerAddress:
+                description: Backend OAP server address
                 type: string
-              type: array
-            internalAddress:
-              type: string
-            ports:
-              description: Ports that will be exposed by this service.
-              items:
+              image:
+                description: Image is the UI Docker image to deploy.
+                type: string
+              instances:
+                description: Count is the number of UI pods
                 format: int32
                 type: integer
-              type: array
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              service:
+                description: Service relevant settings
+                properties:
+                  ingress:
+                    description: Ingress defines the behavior of an ingress
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects.
+                        type: object
+                      host:
+                        description: Host is the fully qualified domain name of a
+                          network host, as defined by RFC 3986. Note the following
+                          deviations from the "host" part of the URI as defined in
+                          RFC 3986
+                        type: string
+                      ingressClassName:
+                        description: IngressClassName is the name of the IngressClass
+                          cluster resource. The associated IngressClass defines which
+                          controller will implement the resource. This replaces the
+                          deprecated `kubernetes.io/ingress.class` annotation. For
+                          backwards compatibility, when that annotation is set, it
+                          must be given precedence over this field. The controller
+                          may emit a warning if the field and annotation have different
+                          values. Implementations of this API should ignore Ingresses
+                          without a class specified. An IngressClass resource may
+                          be marked as default, which can be used to set a default
+                          value for this field. For more information, refer to the
+                          IngressClass documentation.
+                        type: string
+                      tls:
+                        description: TLS configuration. Currently the Ingress only
+                          supports a single TLS port, 443. If multiple members of
+                          this list specify different hosts, they will be multiplexed
+                          on the same port according to the hostname specified through
+                          the SNI TLS extension, if the ingress controller fulfilling
+                          the ingress supports SNI.
+                        items:
+                          description: IngressTLS describes the transport layer security
+                            associated with an Ingress.
+                          properties:
+                            hosts:
+                              description: Hosts are a list of hosts included in the
+                                TLS certificate. The values in this list must match
+                                the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller
+                                fulfilling this Ingress, if left unspecified.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            secretName:
+                              description: SecretName is the name of the secret used
+                                to terminate TLS traffic on port 443. Field is left
+                                optional to allow TLS routing based on SNI hostname
+                                alone. If the SNI host in a listener conflicts with
+                                the "Host" header field used by an IngressRule, the
+                                SNI host is used for termination and value of the
+                                Host header is used for routing.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  template:
+                    description: ServiceTemplate defines the behavior of a service.
+                    properties:
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.
+                        items:
+                          type: string
+                        type: array
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs.
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        description: type determines how the Service is exposed.
+                        type: string
+                    type: object
+                type: object
+              version:
+                description: Version of UI.
+                type: string
+            required:
+            - instances
+            - version
+            type: object
+          status:
+            description: UIStatus defines the observed state of UI
+            properties:
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of the underlying
+                  deployment's current state.
+                items:
+                  description: DeploymentCondition describes the state of a deployment
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of deployment condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalIPs:
+                description: externalIPs is a list of IP addresses for which nodes
+                  in the cluster will also accept traffic for this service.
+                items:
+                  type: string
+                type: array
+              internalAddress:
+                type: string
+              ports:
+                description: Ports that will be exposed by this service.
+                items:
+                  format: int32
+                  type: integer
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/operator/crd/patches/cainjection_in_fetchers.yaml
+++ b/config/operator/crd/patches/cainjection_in_fetchers.yaml
@@ -17,7 +17,7 @@
 
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/operator/crd/patches/cainjection_in_javaagents.yaml
+++ b/config/operator/crd/patches/cainjection_in_javaagents.yaml
@@ -17,7 +17,7 @@
 
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/operator/crd/patches/cainjection_in_oapservers.yaml
+++ b/config/operator/crd/patches/cainjection_in_oapservers.yaml
@@ -17,7 +17,7 @@
 
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/operator/crd/patches/cainjection_in_storages.yaml
+++ b/config/operator/crd/patches/cainjection_in_storages.yaml
@@ -17,7 +17,7 @@
 
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/operator/crd/patches/cainjection_in_uis.yaml
+++ b/config/operator/crd/patches/cainjection_in_uis.yaml
@@ -17,7 +17,7 @@
 
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/operator/crd/patches/webhook_in_fetchers.yaml
+++ b/config/operator/crd/patches/webhook_in_fetchers.yaml
@@ -17,7 +17,7 @@
 
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: fetchers.operator.skywalking.apache.org
@@ -25,12 +25,14 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
 

--- a/config/operator/crd/patches/webhook_in_javaagents.yaml
+++ b/config/operator/crd/patches/webhook_in_javaagents.yaml
@@ -17,7 +17,7 @@
 
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: javaagents.operator.skywalking.apache.org
@@ -25,11 +25,13 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/operator/crd/patches/webhook_in_oapservers.yaml
+++ b/config/operator/crd/patches/webhook_in_oapservers.yaml
@@ -17,7 +17,7 @@
 
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: oapservers.operator.skywalking.apache.org
@@ -25,11 +25,13 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/operator/crd/patches/webhook_in_storages.yaml
+++ b/config/operator/crd/patches/webhook_in_storages.yaml
@@ -17,7 +17,7 @@
 
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: storages.operator.skywalking.apache.org
@@ -25,11 +25,13 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/operator/crd/patches/webhook_in_uis.yaml
+++ b/config/operator/crd/patches/webhook_in_uis.yaml
@@ -17,7 +17,7 @@
 
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: uis.operator.skywalking.apache.org
@@ -25,12 +25,14 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    webhookClientConfig:
-      # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-      # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-      caBundle: Cg==
-      service:
-        namespace: system
-        name: webhook-service
-        path: /convert
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
 

--- a/config/operator/default/kustomization.yaml
+++ b/config/operator/default/kustomization.yaml
@@ -52,7 +52,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1alpha2
+    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
@@ -60,7 +60,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1alpha2
+    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/config/operator/default/webhookcainjection_patch.yaml
+++ b/config/operator/default/webhookcainjection_patch.yaml
@@ -17,14 +17,14 @@
 
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/operator/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/operator/rbac/auth_proxy_client_clusterrole.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/config/operator/webhook/manifests.yaml
+++ b/config/operator/webhook/manifests.yaml
@@ -17,14 +17,15 @@
 
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -41,8 +42,10 @@ webhooks:
     - UPDATE
     resources:
     - fetchers
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -59,8 +62,10 @@ webhooks:
     - UPDATE
     resources:
     - pods
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -77,8 +82,10 @@ webhooks:
     - UPDATE
     resources:
     - javaagents
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -95,8 +102,10 @@ webhooks:
     - UPDATE
     resources:
     - oapservers
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -113,8 +122,10 @@ webhooks:
     - UPDATE
     resources:
     - storages
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -131,16 +142,18 @@ webhooks:
     - UPDATE
     resources:
     - uis
+  sideEffects: None
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
-- clientConfig:
-    caBundle: Cg==
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -157,8 +170,10 @@ webhooks:
     - UPDATE
     resources:
     - fetchers
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -175,8 +190,10 @@ webhooks:
     - UPDATE
     resources:
     - javaagents
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -193,8 +210,10 @@ webhooks:
     - UPDATE
     resources:
     - oapservers
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -211,8 +230,10 @@ webhooks:
     - UPDATE
     resources:
     - storages
-- clientConfig:
-    caBundle: Cg==
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
     service:
       name: webhook-service
       namespace: system
@@ -229,4 +250,5 @@ webhooks:
     - UPDATE
     resources:
     - uis
+  sideEffects: None
 

--- a/config/operator/webhook/ns_selector_patch.yaml
+++ b/config/operator/webhook/ns_selector_patch.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration

--- a/controllers/operator/ui_controller.go
+++ b/controllers/operator/ui_controller.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apiequal "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -128,6 +128,6 @@ func (r *UIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&uiv1alpha1.UI{}).
 		Owns(&apps.Deployment{}).
 		Owns(&core.Service{}).
-		Owns(&networkingv1beta1.Ingress{}).
+		Owns(&networkingv1.Ingress{}).
 		Complete(r)
 }

--- a/controllers/operator/ui_controller_test.go
+++ b/controllers/operator/ui_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -169,7 +169,7 @@ func TestUIIngressOnReconciliation(t *testing.T) {
 		assert.NotEmpty(t, list.Items)
 	}
 	{
-		list := &networkingv1beta1.IngressList{}
+		list := &networkingv1.IngressList{}
 		err = k8sClient.List(context.Background(), list, opts...)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, list.Items)

--- a/hack/install-kubebuilder.sh
+++ b/hack/install-kubebuilder.sh
@@ -19,6 +19,11 @@ set -ex
 
 os=$(go env GOOS)
 arch=$(go env GOARCH)
-curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
-sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+export K8S_VERSION=1.19.2
 export PATH=$PATH:/usr/local/kubebuilder/bin
+sudo mkdir -p /usr/local/kubebuilder/bin
+curl -sSLo kubebuilder https://github.com/kubernetes-sigs/kubebuilder/releases/download/v3.2.0/kubebuilder_${os}_${arch}
+sudo mv ./kubebuilder /usr/local/bin/
+
+curl -sSLo envtest-bins.tar.gz "https://go.kubebuilder.io/test-tools/${K8S_VERSION}/${os}/${arch}"
+sudo  tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz

--- a/pkg/operator/manifests/ui/templates/ingress.yaml
+++ b/pkg/operator/manifests/ui/templates/ingress.yaml
@@ -17,7 +17,7 @@
  
 {{- $ingress := .Spec.Service.Ingress }}
 {{ if $ingress.Host }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Name }}-ui
@@ -36,10 +36,13 @@ spec:
     - host: {{ $ingress.Host }}
       http:
         paths:
-          - path: /*
-            backend:
-              serviceName: {{ .Name }}-ui
-              servicePort: 80
+        - backend:
+            service:
+              name: {{ .Name }}-ui
+              port:
+                number: 80
+          path: /
+          pathType: Prefix
   {{- if $ingress.IngressClassName }}
   ingressClassName: {{ $ingress.IngressClassName }}
   {{end}}

--- a/pkg/operator/repo/assets.gen.go
+++ b/pkg/operator/repo/assets.gen.go
@@ -35,7 +35,7 @@
 // storage/elasticsearch/templates/service_account.yaml (1.095kB)
 // storage/elasticsearch/templates/statefulset.yaml (6.624kB)
 // ui/templates/deployment.yaml (2.604kB)
-// ui/templates/ingress.yaml (1.668kB)
+// ui/templates/ingress.yaml (1.716kB)
 // ui/templates/service.yaml (1.681kB)
 
 package repo
@@ -1493,7 +1493,7 @@ var _uiTemplatesIngressYaml = []byte(`# Licensed to Apache Software Foundation (
  
 {{- $ingress := .Spec.Service.Ingress }}
 {{ if $ingress.Host }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Name }}-ui
@@ -1512,10 +1512,13 @@ spec:
     - host: {{ $ingress.Host }}
       http:
         paths:
-          - path: /*
-            backend:
-              serviceName: {{ .Name }}-ui
-              servicePort: 80
+        - backend:
+            service:
+              name: {{ .Name }}-ui
+              port:
+                number: 80
+          path: /
+          pathType: Prefix
   {{- if $ingress.IngressClassName }}
   ingressClassName: {{ $ingress.IngressClassName }}
   {{end}}
@@ -1537,7 +1540,7 @@ func uiTemplatesIngressYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "ui/templates/ingress.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc9, 0xd6, 0x97, 0xa8, 0x94, 0x74, 0x9b, 0x91, 0x91, 0xba, 0x4a, 0xe8, 0xe9, 0x7a, 0xdf, 0x86, 0x15, 0xec, 0x29, 0x6a, 0x30, 0xce, 0x38, 0x87, 0x98, 0x15, 0xaf, 0x36, 0xb0, 0x10, 0xc9, 0x44}}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa7, 0x22, 0xaf, 0xa7, 0x77, 0x36, 0x3a, 0x57, 0x1c, 0x52, 0x67, 0x42, 0xa0, 0x4a, 0xcf, 0xf7, 0xe9, 0x91, 0x75, 0x45, 0xdf, 0xdc, 0xa3, 0x68, 0x5c, 0x79, 0xc0, 0xbe, 0xf8, 0xb1, 0x61, 0x5e}}
 	return a, nil
 }
 


### PR DESCRIPTION
This PR includes the following change:
- Generate CRD with controller-gen 0.7.0 to update CRD API Version to apiextensions.k8s.io/v1
- Change cert-manager API Version cert-manager.io/v1, since the older v1alpha2 is no longer supported by cert-manange 1.x
- Change Ingress API version to networking.k8s.io/v1.

Reffer to apache/skywalking#8136

Signed-off-by: Roland.Ma <rolandma@kubesphere.io>