### PR TITLE
Use  `kubectl apply -k` to install operator and adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ SWCK is a platform for the SkyWalking user that provisions, upgrades, maintains 
 
 # Quick Start
 
-* Go to the [download page](https://skywalking.apache.org/downloads/#SkyWalkingCloudonKubernetes) to download the latest release binary, `skywalking-swck-<SWCK_VERSION>-bin.tgz`. Unarchive the package to
-a folder named `skywalking-swck-<SWCK_VERSION>-bin`
-
 ## Java Agent Injector
 
 * Install the [Operator](#operator)
@@ -40,10 +37,16 @@ For more details, please read [Java agent injector](/docs/java-agent-injector.md
 ## Operator
 
 * To install the operator in an existing cluster, ensure you have [`cert-manager`](https://cert-manager.io/docs/installation/) installed.
-* Apply the manifests for the Controller and CRDs in release/config:
+* Apply the manifests for the Controller and CRDs based on **Master Branch** or **Stable Release**:
  
  ```
- kubectl apply -f skywalking-swck-<SWCK_VERSION>-bin/config/operator-bundle.yaml
+ kubectl apply -k "github.com/apache/skywalking-swck/operator/config/default"
+ ```
+
+or
+
+ ```
+ kubectl apply -k "github.com/apache/skywalking-swck/operator/config/default?ref=v0.7.0"
  ```
 
 For more details, please refer to [deploy operator](docs/operator.md)
@@ -51,10 +54,16 @@ For more details, please refer to [deploy operator](docs/operator.md)
 ## Custom Metrics Adapter
   
 * Deploy the OAP server by referring to Operator Quick Start.
-* Apply the manifests for an adapter in release/adapter/config:
+* Apply the manifests for an adapter based on **Master Branch** or **Stable Release**:
  
  ```
- kubectl apply -f skywalking-swck-<SWCK_VERSION>-bin/config/adapter-bundle.yaml
+ kubectl apply -k "github.com/apache/skywalking-swck/adapter/config"
+ ```
+
+or
+
+ ```
+ kubectl apply -k "github.com/apache/skywalking-swck/adapter/config?ref=v0.7.0"
  ```
 
 For more details, please read [Custom metrics adapter](docs/custom-metrics-adapter.md)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ SWCK is a platform for the SkyWalking user that provisions, upgrades, maintains 
 
 # Quick Start
 
+There are two ways to install swck.
+* Go to the [download page](https://skywalking.apache.org/downloads/#SkyWalkingCloudonKubernetes) to download the latest release binary, `skywalking-swck-<SWCK_VERSION>-bin.tgz`. Unarchive the package to a folder named `skywalking-swck-<SWCK_VERSION>-bin`
+* Apply the kustomization directory from github.
+
 ## Java Agent Injector
 
 * Install the [Operator](#operator)
@@ -37,7 +41,13 @@ For more details, please read [Java agent injector](/docs/java-agent-injector.md
 ## Operator
 
 * To install the operator in an existing cluster, ensure you have [`cert-manager`](https://cert-manager.io/docs/installation/) installed.
-* Apply the manifests for the Controller and CRDs based on **Master Branch** or **Stable Release**:
+* Apply the manifests for the Controller and CRDs in release/config:
+
+ ```
+ kubectl apply -f skywalking-swck-<SWCK_VERSION>-bin/config/operator-bundle.yaml
+ ```
+
+* Also, you could deploy the operator quickly based on **Master Branch** or **Stable Release**:
  
  ```
  kubectl apply -k "github.com/apache/skywalking-swck/operator/config/default"
@@ -54,7 +64,12 @@ For more details, please refer to [deploy operator](docs/operator.md)
 ## Custom Metrics Adapter
   
 * Deploy the OAP server by referring to Operator Quick Start.
-* Apply the manifests for an adapter based on **Master Branch** or **Stable Release**:
+* Apply the manifests for an adapter in release/adapter/config:
+
+ ```
+ kubectl apply -f skywalking-swck-<SWCK_VERSION>-bin/config/adapter-bundle.yaml
+ ```
+* Also, you could deploy the adapter quickly based on **Master Branch** or **Stable Release**:
  
  ```
  kubectl apply -k "github.com/apache/skywalking-swck/adapter/config"


### PR DESCRIPTION
Kubectl supports applying a kustomization directory from a web page(such as github). It's easier than installing from release binary.