### PR TITLE
Fix panic in storage reconciler.

### DIFF
--- a/operator/main.go
+++ b/operator/main.go
@@ -113,6 +113,7 @@ func main() {
 		Scheme:     mgr.GetScheme(),
 		FileRepo:   manifests.NewRepo("storage"),
 		RestConfig: mgr.GetConfig(),
+		Recorder:   mgr.GetEventRecorderFor("storage-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Storage")
 		os.Exit(1)

--- a/operator/main.go
+++ b/operator/main.go
@@ -94,7 +94,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		FileRepo: manifests.NewRepo("ui"),
-		Recorder: mgr.GetEventRecorderFor("oapserver-controller"),
+		Recorder: mgr.GetEventRecorderFor("ui-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UI")
 		os.Exit(1)


### PR DESCRIPTION
When I create an internal storage, the storage reconciler will panic at `/workspace/pkg/kubernetes/apply.go:69`

```
apiVersion: operator.skywalking.apache.org/v1alpha1
kind: Storage
metadata:
  name: sw-storage
  namespace: skywalking-system
spec:
  type: elasticsearch
  connectType: internal
  version: 7.5.1
  instances: 1
  image: elasticsearch:7.5.1
  resource:
    limit: "2000m"
    requests: "1000m"
  security:
    user:
      secretName: sw-storage-secret
    tls: false
```
```
1.6941491242827754e+09  INFO    Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference        {"controller": "storage", "controllerGroup": "operator.skywalking.apache.org", "controllerKind": "Storage", "storage": {"name":"sw-storage","namespace":"skywalking-system"}, "namespace": "skywalking-system", "name": "sw-storage", "reconcileID": "09679ed5-2fbd-488d-a16a-8aaf5e78672c"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x14e4549]

goroutine 678 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:118 +0x1f4
panic({0x1666a20, 0x25e62c0})
        /usr/local/go/src/runtime/panic.go:884 +0x213
github.com/apache/skywalking-swck/operator/pkg/kubernetes.(*Application).ApplyAll(0xc0011d5bf8, {0x1a9d150, 0xc001285fb0}, {0xc000133800?, 0x4, 0xc000713320?}, {{0x1a9f290?, 0xc0015a0000?}, 0xc001548a00?})
        /workspace/pkg/kubernetes/apply.go:69 +0x469
github.com/apache/skywalking-swck/operator/controllers/operator.(*StorageReconciler).Reconcile(0xc000578340, {0x1a9d150, 0xc001285fb0}, {{{0xc000418750?, 0x0?}, {0xc000713320?, 0x40dee7?}}})
        /workspace/controllers/operator/storage_controller.go:99 +0x45a
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1a9d0a8?, {0x1a9d150?, 0xc001285fb0?}, {{{0xc000418750?, 0x1781340?}, {0xc000713320?, 0xc0007307e8?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:121 +0xc8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000371680, {0x1a9d0a8, 0xc0000bf810}, {0x16bf6c0?, 0xc00030c5c0?})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:320 +0x309
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000371680, {0x1a9d0a8, 0xc0000bf810})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:273 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:234 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:230 +0x587
```