### PR TITLE
Use append rather than replace policy for JAVA_TOOL_OPTIONS

### DIFF
--- a/operator/apis/operator/v1alpha1/swagent_webhook.go
+++ b/operator/apis/operator/v1alpha1/swagent_webhook.go
@@ -107,7 +107,7 @@ func (r *SwAgent) setDefault() {
 			r.Spec.JavaSidecar.Args = append(r.Spec.JavaSidecar.Args, "-c")
 			r.Spec.JavaSidecar.Args = append(r.Spec.JavaSidecar.Args, "mkdir -p /sky/agent && cp -r /skywalking/agent/* /sky/agent")
 		}
-		r.setOrAddEnv("JAVA_TOOL_OPTIONS", " -javaagent:/sky/agent/skywalking-agent.jar")
+		r.setOrAppendEnv("JAVA_TOOL_OPTIONS", " -javaagent:/sky/agent/skywalking-agent.jar")
 
 		// default values for shared volume
 		if len(r.Spec.SharedVolumeName) == 0 {
@@ -117,8 +117,8 @@ func (r *SwAgent) setDefault() {
 	}
 }
 
-func (r *SwAgent) setOrAddEnv(envKey string, envValue string) {
-	if !r.setEnvIfExists(&r.Spec.JavaSidecar.Env, envKey, envValue) {
+func (r *SwAgent) setOrAppendEnv(envKey string, envValue string) {
+	if !r.appendEnvIfExists(&r.Spec.JavaSidecar.Env, envKey, envValue) {
 		javaToolOptionsEnv := corev1.EnvVar{
 			Name:  envKey,
 			Value: envValue,
@@ -127,10 +127,10 @@ func (r *SwAgent) setOrAddEnv(envKey string, envValue string) {
 	}
 }
 
-func (r *SwAgent) setEnvIfExists(envs *[]corev1.EnvVar, envKey string, envValue string) bool {
+func (r *SwAgent) appendEnvIfExists(envs *[]corev1.EnvVar, envKey string, envValue string) bool {
 	for _, env := range *envs {
 		if strings.EqualFold(env.Name, envKey) {
-			env.Value = envValue
+			env.Value += envValue
 			return true
 		}
 	}


### PR DESCRIPTION
When there is already `JAVA_TOOL_OPTIONS`, i.e. `JAVA_TOOL_OPTIONS=-javaagent:/tmp/a.jar`, currently skywalking-swck will replace it to `JAVA_TOOL_OPTIONS=-javaagent:/path/skywalking.jar`, which override user's setting.

skywalking should append to JAVA_TOOL_OPTIONS, like `JAVA_TOOL_OPTIONS=-javaagent:/tmp/a.jar -javaagent:/path/skywalking.jar`.