### PR TITLE
bump up the ingress apiVersion from networking.k8s.io/v1beta1 to networking.k8s.io/v1 for oapserver manifest

### DIFF
--- a/operator/pkg/operator/manifests/oapserver/templates/ingress.yaml
+++ b/operator/pkg/operator/manifests/oapserver/templates/ingress.yaml
@@ -17,7 +17,7 @@
  
 {{- $ingress := .Spec.Service.Ingress }}
 {{ if $ingress.Host }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Name }}-ui


### PR DESCRIPTION
bump up the ingress apiVersion from networking.k8s.io/v1beta1 to networking.k8s.io/v1 for oapserver manifest. close https://github.com/apache/skywalking/issues/11504