### PR TITLE
Overlay javaagent by pod annotation.

### DIFF
--- a/operator/controllers/operator/javaagent_controller.go
+++ b/operator/controllers/operator/javaagent_controller.go
@@ -98,6 +98,7 @@ func (r *JavaAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	config := map[string]string{}
 	r.injectConfigBySwAgent(lastMatchedSwAgent, config)
+	r.injectConfigByPodAnnotations(pod.ObjectMeta.Annotations, config)
 
 	// only get the first selector label from labels as podselector
 	labels := pod.Labels
@@ -169,6 +170,19 @@ func (r *JavaAgentReconciler) injectConfigBySwAgent(lastMatchedSwAgent *operator
 				config[operatorv1alpha1.ServiceName] = env.Value
 			}
 		}
+	}
+}
+
+func (r *JavaAgentReconciler) injectConfigByPodAnnotations(podAnnotations map[string]string, config map[string]string) {
+	if podAnnotations == nil {
+		return
+	}
+
+	if v, ok := podAnnotations["agent.skywalking.apache.org/collector.backend_service"]; ok {
+		config[operatorv1alpha1.BackendService] = v
+	}
+	if v, ok := podAnnotations["agent.skywalking.apache.org/agent.service_name"]; ok {
+		config[operatorv1alpha1.ServiceName] = v
 	}
 }
 


### PR DESCRIPTION
I use workload annotations to inject agent agent name and collector backend_service, I fount javaagent can not get the correct value:
```
[root@15 ~]# kubectl get javaagent -A
NAMESPACE     NAME                     PODSELECTOR    SERVICENAME            BACKENDSERVICE
gray-demo     app-consumer-javaagent   app=consumer   Your_ApplicationName   127.0.0.1:11800
``` 

So I add a method `injectConfigByPodAnnotations` after `injectConfigBySwAgent`, then javaagent_controller can overlay config by using pod annotations:
```
[root@15 ~]# kubectl get javaagent -A
NAMESPACE     NAME                     PODSELECTOR    SERVICENAME                   BACKENDSERVICE
gray-demo     app-consumer-javaagent   app=consumer   cluster01-default::consumer   192.168.6.71:11800
```