### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,17 @@ updates:
       interval: "daily"
     assignees:
       - "kezhenxu94"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
   - package-ecosystem: "gomod"
     directory: "/operator"
     schedule:
       interval: "daily"
     assignees:
       - "kezhenxu94"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/adapter"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "kezhenxu94"
+  - package-ecosystem: "gomod"
+    directory: "/operator"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "kezhenxu94"


### PR DESCRIPTION
We can re-generate the license file but pushing the changes to the PR that dependabot opened won’t trigger the CI checks, this is by design in GitHub Actions to avoid infinite recursive workflow runs, so in this PR, I just assign myself and after dependabot open the PR, I’ll take the remaining steps to update the license and merge it.