### PR TITLE
fix: align EventExporter field naming with instances convention

### DIFF
--- a/operator/apis/operator/v1alpha1/eventexporter_types.go
+++ b/operator/apis/operator/v1alpha1/eventexporter_types.go
@@ -31,7 +31,7 @@ type EventExporterSpec struct {
 	Image string `json:"image,omitempty"`
 	// Instances is the number of event exporter pods
 	// +kubebuilder:validation:Required
-	Instances int32 `json:"replicas,omitempty"`
+	Instances int32 `json:"instances"`
 	// Config of filters and exporters
 	// +kubebuilder:validation:Optional
 	Config string `json:"config,omitempty"`

--- a/operator/apis/operator/v1alpha1/eventexporter_types.go
+++ b/operator/apis/operator/v1alpha1/eventexporter_types.go
@@ -29,9 +29,9 @@ type EventExporterSpec struct {
 	Version string `json:"version,omitempty"`
 	// Image is the event exporter Docker image to deploy.
 	Image string `json:"image,omitempty"`
-	// Replicas is the number of event exporter pods
+	// Instances is the number of event exporter pods
 	// +kubebuilder:validation:Required
-	Replicas int32 `json:"replicas,omitempty"`
+	Instances int32 `json:"replicas,omitempty"`
 	// Config of filters and exporters
 	// +kubebuilder:validation:Optional
 	Config string `json:"config,omitempty"`

--- a/operator/apis/operator/v1alpha1/eventexporter_webhook.go
+++ b/operator/apis/operator/v1alpha1/eventexporter_webhook.go
@@ -56,8 +56,8 @@ func (r *EventExporter) Default(_ context.Context, eventexporter *EventExporter)
 		eventexporter.Spec.Image = fmt.Sprintf("%s:%s", image, eventexporter.Spec.Version)
 	}
 
-	if eventexporter.Spec.Replicas == 0 {
-		eventexporter.Spec.Replicas = 1
+	if eventexporter.Spec.Instances == 0 {
+		eventexporter.Spec.Instances = 1
 	}
 
 	return nil

--- a/operator/config/crd/bases/operator.skywalking.apache.org_eventexporters.yaml
+++ b/operator/config/crd/bases/operator.skywalking.apache.org_eventexporters.yaml
@@ -76,7 +76,7 @@ spec:
               image:
                 description: Image is the event exporter Docker image to deploy.
                 type: string
-              replicas:
+              instances:
                 description: Instances is the number of event exporter pods
                 format: int32
                 type: integer
@@ -84,7 +84,7 @@ spec:
                 description: Version of EventExporter.
                 type: string
             required:
-            - replicas
+            - instances
             - version
             type: object
           status:

--- a/operator/config/crd/bases/operator.skywalking.apache.org_eventexporters.yaml
+++ b/operator/config/crd/bases/operator.skywalking.apache.org_eventexporters.yaml
@@ -77,7 +77,7 @@ spec:
                 description: Image is the event exporter Docker image to deploy.
                 type: string
               replicas:
-                description: Replicas is the number of event exporter pods
+                description: Instances is the number of event exporter pods
                 format: int32
                 type: integer
               version:

--- a/operator/config/samples/eventexporter.yaml
+++ b/operator/config/samples/eventexporter.yaml
@@ -20,7 +20,7 @@ kind: EventExporter
 metadata:
   name: eventexporter-sample
 spec:
-  replicas: 1
+  instances: 1
   config: |
     filters:
       - reason: ""     

--- a/operator/pkg/operator/manifests/eventexporter/templates/deployment.yaml
+++ b/operator/pkg/operator/manifests/eventexporter/templates/deployment.yaml
@@ -26,7 +26,7 @@ metadata:
     operator.skywalking.apache.org/application: eventexporter
     operator.skywalking.apache.org/component: deployment
 spec:
-  replicas: {{ .Spec.Replicas }}
+  replicas: {{ .Spec.Instances }}
   selector:
     matchLabels:
       operator.skywalking.apache.org/eventexporter-name: {{ .Name }}

--- a/test/e2e/skywalking-components-with-eventexporter.yaml
+++ b/test/e2e/skywalking-components-with-eventexporter.yaml
@@ -35,7 +35,7 @@ metadata:
   name: skywalking-system
   namespace: skywalking-system
 spec:
-  replicas: 1
+  instances: 1
   version: latest
   config: |
     filters:


### PR DESCRIPTION
## Summary

- Rename the `Replicas` Go field to `Instances` in `EventExporterSpec` to match the naming convention used by all other operator types (`OAPServer`, `Satellite`, `UI`, `Storage`)
- Update the webhook default handler to reference `Spec.Instances`
- Update the CRD YAML field description accordingly

## Test plan

- [ ] Verify `kubectl get eventexporters` shows the correct column
- [ ] Verify webhook defaulting sets `Instances = 1` when unset
- [ ] Run existing operator tests