### PR TITLE
cves: bump adapter Go to 1.25.10 to fix stdlib CVEs

### DIFF
--- a/adapter/go.mod
+++ b/adapter/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/skywalking-swck/adapter
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/apache/skywalking-cli v0.0.0-20210209032327-04a0ce08990f


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `adapter/go.mod` from `1.25.9` to `1.25.10` to fix multiple stdlib CVEs.

## CVEs Fixed

| CVE ID | Severity | Fix |
|--------|----------|-----|
| CVE-2026-33811 | LOW | Go stdlib 1.25.9 → 1.25.10 |
| CVE-2026-33814 | LOW | Go stdlib 1.25.9 → 1.25.10 |
| CVE-2026-39820 | LOW | Go stdlib 1.25.9 → 1.25.10 |
| CVE-2026-39823 | LOW | Go stdlib 1.25.9 → 1.25.10 |
| CVE-2026-39825 | LOW | Go stdlib 1.25.9 → 1.25.10 |
| CVE-2026-39826 | LOW | Go stdlib 1.25.9 → 1.25.10 |
| CVE-2026-39836 | LOW | Go stdlib 1.25.9 → 1.25.10 |
| CVE-2026-42499 | LOW | Go stdlib 1.25.9 → 1.25.10 |

cc @kezhenxu94