### PR TITLE
cves: bump adapter Go to 1.26.3 to fix stdlib CVEs

### DIFF
--- a/adapter/Dockerfile
+++ b/adapter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.26 As builder
+FROM golang:1.26.3 As builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/adapter/go.mod
+++ b/adapter/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/skywalking-swck/adapter
 
-go 1.25.10
+go 1.26.3
 
 require (
 	github.com/apache/skywalking-cli v0.0.0-20210209032327-04a0ce08990f

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.26 AS builder
+FROM golang:1.26.3 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/skywalking-swck/operator
 
-go 1.26.0
+go 1.26.3
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Bumps the adapter Go version from 1.25.10 to 1.26.3 to fix multiple Go stdlib CVEs, and aligns the adapter Dockerfile (which already used `golang:1.26`) to use the explicit `golang:1.26.3` image.

## Changes

- `adapter/go.mod`: `go 1.25.10` → `go 1.26.3`
- `adapter/Dockerfile`: `FROM golang:1.26` → `FROM golang:1.26.3`

Note: The operator already declared `go 1.26.0` (via edf1575); this PR brings the adapter up to the same minor line and pins to the latest patch.

cc @kezhenxu94