### PR TITLE
Declare TARGETARCH with no default, so buildx can actually set it

### DIFF
--- a/adapter/Dockerfile
+++ b/adapter/Dockerfile
@@ -32,13 +32,14 @@ COPY main.go main.go
 COPY pkg/ pkg/
 
 # Build
-# TARGETARCH is supplied per platform by buildx. .github/workflows/publish-docker.yml
-# builds this image for linux/amd64 AND linux/arm64, and now stamps release version tags
-# on the result; a hardcoded GOARCH=amd64 would put an amd64 binary inside the arm64
-# manifest, so every arm64 node would fail with "exec format error". The default keeps a
-# plain `docker build` (make docker-build, used by the e2e suites) building amd64 as before.
-ARG TARGETARCH=amd64
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o adapter main.go
+# TARGETARCH is supplied per platform by buildx, and MUST be declared with no default. Giving a
+# predefined platform argument a default makes BuildKit treat it as an ordinary build argument and
+# use that default, so `ARG TARGETARCH=amd64` reported amd64 even when building for arm64 -- which
+# put an amd64 binary inside the arm64 manifest, the exact failure this was meant to prevent. The
+# shell default below covers a plain `docker build` (make docker-build, used by the e2e suites),
+# where the variable may be unset.
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-$(go env GOARCH)} GO111MODULE=on go build -a -o adapter main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/build/images/Dockerfile.release
+++ b/build/images/Dockerfile.release
@@ -52,15 +52,11 @@ RUN set -eux; \
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-# TARGETARCH is supplied per platform by buildx, and the release tarball carries a binary per
-# supported architecture (operator/Makefile and adapter/Makefile release-build).
-#
-# Hardcoding -linux-amd64 here is how apache/skywalking-swck:0.10.0 came to advertise linux/arm64
-# while its arm64 manifest reused the amd64 layers byte for byte: /manager inside it is an x86-64
-# ELF, so an arm64 node gets "exec format error". Selecting on TARGETARCH is what makes the
-# multi-platform manifest honest, and it fails the build loudly -- rather than silently shipping
-# the wrong binary -- if a release tarball does not carry that architecture.
-ARG TARGETARCH=amd64
+# TARGETARCH is supplied per platform by buildx, and MUST be declared with no default: giving a
+# predefined platform argument a default makes BuildKit use that default instead of the target's
+# architecture, which is how an amd64 binary ended up inside an arm64 manifest. The release tarball
+# carries a binary per architecture and this selects the right one.
+ARG TARGETARCH
 COPY --from=builder --chown=65532:65532 /swck/bin/manager-linux-${TARGETARCH} /manager
 COPY --from=builder --chown=65532:65532 /swck/bin/adapter-linux-${TARGETARCH} /adapter
 USER 65532:65532

--- a/docs/en/changes/changes.md
+++ b/docs/en/changes/changes.md
@@ -1,5 +1,8 @@
 ## 0.11.0
 
+#### Bugs
+- Build genuinely multi-architecture images, again. The previous fix declared `ARG TARGETARCH=amd64` in each Dockerfile, and giving a *predefined* platform argument a default makes BuildKit use that default instead of the target's architecture -- so `TARGETARCH` read `amd64` even when building for `linux/arm64`, the builder stage ran once, and the amd64 binary was copied into the arm64 manifest. The publish workflow's own ELF check caught it on the first run that was ever able to start. The argument is declared with no default now, and the shell falls back to the native architecture for a plain `docker build`, which was also producing amd64 binaries on an arm64 host.
+
 #### Features
 - Release the `skywalking-swck` Helm chart from this repository. One chart installs the operator and, behind a values flag, the custom metrics adapter. The CRDs, the operator's ClusterRole and the admission webhook configurations it ships are generated from the operator sources by `make chart-manifests`, and CI fails on any drift.
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -34,13 +34,14 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-# TARGETARCH is supplied per platform by buildx. .github/workflows/publish-docker.yml
-# builds this image for linux/amd64 AND linux/arm64, and now stamps release version tags
-# on the result; a hardcoded GOARCH=amd64 would put an amd64 binary inside the arm64
-# manifest, so every arm64 node would fail with "exec format error". The default keeps a
-# plain `docker build` (make docker-build, used by the e2e suites) building amd64 as before.
-ARG TARGETARCH=amd64
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go
+# TARGETARCH is supplied per platform by buildx, and MUST be declared with no default. Giving a
+# predefined platform argument a default makes BuildKit treat it as an ordinary build argument and
+# use that default, so `ARG TARGETARCH=amd64` reported amd64 even when building for arm64 -- which
+# put an amd64 binary inside the arm64 manifest, the exact failure this was meant to prevent. The
+# shell default below covers a plain `docker build` (make docker-build, used by the e2e suites),
+# where the variable may be unset.
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-$(go env GOARCH)} GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
The arm64 fix that shipped in #214 does not work, and the publish workflow's own ELF check
caught it on the first run that was ever able to start.

Each Dockerfile declared `ARG TARGETARCH=amd64`. Giving a **predefined** platform argument a
default makes BuildKit treat it as an ordinary build argument and use that default, so
`TARGETARCH` read `amd64` even when the target was `linux/arm64`. The builder stage is pinned
to `$BUILDPLATFORM`, so with the argument identical across targets it ran exactly once and its
amd64 binary was copied into both manifest entries.

Verified against the published image rather than inferred. The arm64 entry of
`ghcr.io/apache/skywalking-swck/operator:eb86203` has a config saying `architecture: arm64`
and a `/manager` that is `ELF 64-bit LSB executable, x86-64`. The two platform entries have
different digests — the distroless base layers differ — which is why this is easy to miss by
looking at the manifest alone.

### The mechanism, A/B

```
ARG TARGETARCH=amd64   building for linux/arm64  ->  TARGETARCH=amd64   (wrong)
ARG TARGETARCH         building for linux/arm64  ->  TARGETARCH=arm64   (correct)
```

### Verified

A real multi-platform build, on an arm64 host, now runs the builder twice and produces:

```
index says linux/amd64   config says amd64   /manager is: x86-64
index says linux/arm64   config says arm64   /manager is: ARM aarch64
```

`build/images/Dockerfile.release` selects a prebuilt per-architecture binary rather than
compiling, and had the same trap. With the old default, `linux/arm64` selected
`manager-linux-amd64`; it now selects `manager-linux-arm64`.

### The default was not harmless elsewhere either

It was added to keep a plain `docker build` working for the e2e suites. It broke that too: on
an arm64 host `make docker-build` was producing amd64 binaries for a kind cluster that wants
native ones. The shell fallback keeps that case working without shadowing what buildx supplies.

### Why this reached master

`publish-docker.yml` had never run to completion. Its actions were pinned to SHAs outside the
ASF allow-list, so the gateway rejected it before any job started — a run with zero jobs and a
`startup_failure` conclusion, which reads as "nothing to do" rather than "broken". #214 fixed
the pins, and the run on the merge commit was the first ever to execute. It failed on exactly
the check written for this class of bug.